### PR TITLE
Fix bug#61:Undefined Namespace prefix xsd is used in wsdl_customizati…

### DIFF
--- a/api/src/main/resources/javax/xml/ws/wsdl_customizationschema_2_0.xsd
+++ b/api/src/main/resources/javax/xml/ws/wsdl_customizationschema_2_0.xsd
@@ -4,8 +4,8 @@
            elementFormDefault="qualified"
            targetNamespace="http://java.sun.com/xml/ns/jaxws"
            attributeFormDefault="unqualified">
-  <xsd:annotation>
-    <xsd:documentation>
+  <xs:annotation>
+    <xs:documentation>
 
       Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
 
@@ -15,8 +15,8 @@
 
       SPDX-License-Identifier: BSD-3-Clause
 
-    </xsd:documentation>
-  </xsd:annotation>
+    </xs:documentation>
+  </xs:annotation>
 
     <xs:annotation>
         <xs:documentation>


### PR DESCRIPTION
Fix bug#61:Undefined Namespace prefix "xsd" is used in wsdl_customizationschema_2_0.xsd. 
Bug Id: https://github.com/eclipse-ee4j/jax-ws-api/issues/61
or
https://bugs.eclipse.org/bugs/show_bug.cgi?id=548859

Signed-off-by: Ramesh Mamidala <ramesh.mamidalaa@gmail.com>
