### PR TITLE
#91: API implementation needs to open javax.xml.ws.wsaddressing to java.xml.bind

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -33,5 +33,7 @@ module java.xml.ws {
     exports javax.xml.ws.spi.http;
     exports javax.xml.ws.wsaddressing;
 
+    opens javax.xml.ws.wsaddressing to java.xml.bind;
+
     uses javax.xml.ws.spi.Provider;
 }


### PR DESCRIPTION


Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>