### PR TITLE
[#118] Jakarta-ize Enterprise Web Services Specification Document Chapters 1-4

### DIFF
--- a/enterprise-ws-spec/src/main/asciidoc/ClientProgrammingModel.adoc
+++ b/enterprise-ws-spec/src/main/asciidoc/ClientProgrammingModel.adoc
@@ -224,7 +224,7 @@ names of all the deployed port components in the Jakarta EE application
 unit. This default behavior can be overridden using the
 <port-component-link> deployment descriptor element. Refer to client
 deployment descriptor schema 
-<<DeploymentDescriptors.adoc#section7.2.5,Section 7.2.5>>.
+<<DeploymentDescriptors.adoc#section725,Section 7.2.5>>.
 
 If the name attribute is not specified in this annotation then default
 naming rules apply as specified in the Jakarta EE specification.
@@ -575,7 +575,7 @@ within the client view. The equals() method cannot be used to compare
 two stubs or proxy instances to determine if they represent the same
 Port. The results of the equals(), hash(), and toString() methods for a
 stub are unspecified. There is no way for the client to ensure that a
-Port Stub, Dynamic Proxy, or Call will access a particular Port instance
+Port Stub or Dynamic Proxy will access a particular Port instance
 or the same Port instance for multiple invocations.
 
 ===== Type narrowing
@@ -725,10 +725,10 @@ Jakarta XML Web Services compliant implementations are required to support
 MTOM (Message Transmission Optimization Mechanism)/XOP (XML-binary Optimized
 Packaging) specifications from W3C. Refer to sections 6.5.2, 7.14.2, and
 10.4.1.1 of Jakarta XML Web Services specification. Support for SOAP MTOM/XOP
-mechanism for optimizing transmission of binary data types is provided by JAXB
-which is the data binding for Jakarta XML Web Services. Jakarta XML Web
-Services provides the MIME processing required to enable JAXB to serialize and
-deserialize MIME based MTOM/XOP packages.
+mechanism for optimizing transmission of binary data types is provided by
+Jakarta XML Binding which is the data binding for Jakarta XML Web Services.
+Jakarta XML Web Services provides the MIME processing required to enable 
+Jakarta XML Binding to serialize and deserialize MIME based MTOM/XOP packages.
 
 SOAP MTOM/XOP mechanism on the client can be enabled or disabled by any
 one of the following ways:

--- a/enterprise-ws-spec/src/main/asciidoc/ClientProgrammingModel.adoc
+++ b/enterprise-ws-spec/src/main/asciidoc/ClientProgrammingModel.adoc
@@ -49,8 +49,8 @@ specification. The Service object is a factory used by the client to get
 a stub or proxy that implements the Service Endpoint Interface. The stub
 is the client representation of an instance of the Web service.
 
-The Service Class can be the generic javax.xml.ws.Service class or a Generated
-Service class, which extends javax.xml.ws.Service. Further references in this
+The Service Class can be the generic jakarta.xml.ws.Service class or a Generated
+Service class, which extends jakarta.xml.ws.Service. Further references in this
 document to the ServiceInterface/Class refer to either the generic or generated
 version, unless noted otherwise.
 
@@ -90,7 +90,7 @@ A client can use the stub/proxy methods of the Service Interface/Class
 to get a Port stub or dynamic proxy. The WSDL specific methods can be
 used when the full WSDL definition of the service is available to the
 client developer. The WSDL agnostic methods must be used if the client
-developer has a partial WSDL definition that only contains only the
+developer has a partial WSDL definition that only contains the
 portType and bindings.
 
 With Jakarta XML Web Services, a client can also use the Service Class to work
@@ -131,7 +131,7 @@ Service abf = (Service)ic.lookup(
 "java:comp/env/service/AddressBookService");
 
 In the above example, the container must ensure that an implementation
-of the generic Service Interface, jakarta.xml.ws.Service, is bound in the
+of the generic Service class, jakarta.xml.ws.Service, is bound in the
 JNDI name space at a location specified by the developer. A similar code
 fragment is used for access to an object that implements a Generated Service
 Interface such as AddressBookService.
@@ -205,7 +205,7 @@ AddressBookService other;
 jakarta.jws.HandlerChain annotation can be used with this annotation to
 specify handlers on these client side references. More information on
 the HandlerChain annotation can be found in Jakarta Web Services Metadata
-specification and also in Chapter 6 of this specification.
+specification and also in <<Handlers.adoc#anchor-58, Chapter 6>> of this specification.
 
 If wsdlLocation attribute of WebServiceRef annotation is specified, it
 is always relative to the root of the module. HTTP URL can also be
@@ -223,19 +223,19 @@ the final WSDL document is resolved by comparing the Service name on the
 names of all the deployed port components in the Jakarta EE application
 unit. This default behavior can be overridden using the
 <port-component-link> deployment descriptor element. Refer to client
-deployment descriptor schema Section 7.2.5
+deployment descriptor schema 
+<<DeploymentDescriptors.adoc#section7.2.5,Section 7.2.5>>.
 
 If the name attribute is not specified in this annotation then default
 naming rules apply as specified in the Jakarta EE specification.
 
 The following table summarizes the relationship between the deployment
-descriptors for <service-ref> and member attributes of this annotation .
+descriptors for <service-ref> and member attributes of this annotation.
 
-* Table 1 Relationship between the deployment descriptor elements and
-jakarta.xml.ws.WebServiceRef annotation
-
+[[table1]]
 [cols=",",]
 |===
+| Deployment Descriptor elements | jakarta.xml.ws.WebServiceRef annotation
 |<service-ref> |One per @WebServiceRef annotation
 
 |<service-ref>/<service-ref-name> |@WebServiceRef.name
@@ -268,6 +268,9 @@ only for overriding the default behavior.
 |<service-ref>/<lookup-name> |@WebServiceRef.lookup
 |===
 
+* Table 1 Relationship between the deployment descriptor elements and
+jakarta.xml.ws.WebServiceRef annotation
+
 @WebServiceRef reference instances are not guaranteed to be thread safe.
 If the instances are accessed by multiple threads, usual synchronization
 techniques can be used to support multiple threads.
@@ -281,7 +284,7 @@ use of this annotation is supported.
 ==== Port Lookup
 
 With Jakarta XML Web Services, the client developer can also use JNDI lookups
-for a Port. This is analogous to using the javax.xml.ws.WebServiceRef
+for a Port. This is analogous to using the jakarta.xml.ws.WebServiceRef
 annotation for Service endpoint. The client side deployment descriptor has
 been modified to introduce a new optional element <service-ref-type> that
 declares the type of <service-ref> returned when a dependency injection
@@ -331,13 +334,12 @@ Interface/Class to obtain a static stub or dynamic proxy for a Web
 service.
 
 The container must provide at least one of static stub or dynamic proxy
-support for these methods as described in section
-link:#anchor-30[4.2.5]. The container must ensure the stub or dynamic
-proxy is fully configured for use by the client, before it is returned
-to the client. The deployment time choice of whether a stub or dynamic
-proxy is returned by the getPort or get<port name> methods is out of the
-scope of this specification. Container providers are free to offer
-either one or both.
+support for these methods as described in <<anchor-30,section 4.2.5>>. The
+container must ensure the stub or dynamic proxy is fully configured for use
+by the client, before it is returned to the client. The deployment time
+choice of whether a stub or dynamic proxy is returned by the getPort or
+get<port name> methods is out of the scope of this specification. Container
+providers are free to offer either one or both.
 
 The container provider must provide Port resolution for the
 getPort(java.lang.Class serviceEndpointInterface) method. This is useful
@@ -349,18 +351,17 @@ interface argument to a port is not declared in the client deployment
 descriptor, the container may provide a default resolution capability or
 throw a ServiceException.
 
-===== ServiceFactory
+===== Service Factory
 
-ServiceFactory class has been removed from Jakarta XML Web Services. It has
-been replaced by two static methods Service.create(QName serviceName) and
+Two static factory methods Service.create(QName serviceName) and
 Service.create(URL wsdlLocation, QName serviceName) for creating Service
-instances. These methods rely on specific implementations of
-ServiceDelegate Class in any Jakarta XML Web Services compliant implementation.
-The use of these static methods is not recommended in a Web Services for
-Jakarta EE product. A Web Services for Jakarta EE client must obtain a Service
-Interface/Class using JNDI lookup as described in section
-link:#anchor-26[4.2.1]. Container providers are not required to support
-managed Service instances created using these methods.
+instances rely on specific implementations of ServiceDelegate Class in any
+Jakarta XML Web Services compliant implementation. The use of these static
+methods is not recommended in a Web Services for Jakarta EE product. A Web
+Services for Jakarta EE client must obtain a Service Interface/Class using
+JNDI lookup as described in <<anchor-26, section 4.2.1>>. Container providers
+are not required to support managed Service instances created using these
+methods.
 
 [#anchor-31]
 ===== Service method use with full WSDL
@@ -368,9 +369,9 @@ managed Service instances created using these methods.
 A client developer may use all methods of the Service Interface or class if a
 full WSDL description is declared in the client deployment descriptor.  A
 mapping file is not required because all of the data binding in Jakarta XML
-Web Services is done according to the JAXB specification. The port address
-location attribute of a port using a SOAP/HTTP binding must begin with http:
-or https:.
+Web Services is done according to the Jakarta XML Binding specification. The
+port address location attribute of a port using a SOAP/HTTP binding must begin
+with "http:" or "https:".
 
 If a client developer uses the getPort(SEI) method of a Service
 Interface/Class and the WSDL supports multiple ports the SEI could be
@@ -434,7 +435,7 @@ WebServiceFeature... features);
 A partial WSDL definition is defined as a fully specified WSDL document
 which contains no service or port elements. A mapping file is not required
 and ignored if specified, because all of the data binding in Jakarta XML Web
-Services is done according to the JAXB specification.
+Services is done according to the Jakarta XML Binding specification.
 
 Use of other methods of the Service Interface/Class is not recommended
 when a developer specifies a partial WSDL definition. The behavior of
@@ -498,11 +499,10 @@ recommended. Their behavior is unspecified.
 The following table summarizes the behavior of the methods of the
 Service Interface under various deployment configurations.
 
-
-* Table 2 Service class method behavior with Jakarta XML Web Services
-
+[[table2]]
 [cols=",,,",]
 |===
+|Method |Full WSDL |Partial WSDL |No WSDL
 |void addPort(QName portName, URI bindingId, String endpointAddress)
 |Normal |Normal |Normal
 
@@ -559,6 +559,8 @@ features) |Normal |Unspecified |Unspecified
 features) |Normal |Unspecified |Unspecified
 |===
 
+* Table 2 Service class method behavior with Jakarta XML Web Services
+
 [#anchor-30]
 ==== Port Stub and Dynamic Proxy
 
@@ -599,12 +601,12 @@ in a managed context defined by this specification:
 ===== Required properties
 
 A container provider is required to support the
-javax.xml.ws.service.endpoint.address property to allow
+jakarta.xml.ws.service.endpoint.address property to allow
 components to dynamically redirect a Stub/proxy to a different URI.
 
 ==== Jakarta XML Web Services Dispatch APIs
 
-Client developers may use javax.xml.ws.Dispatch APIs defined in Jakarta XML
+Client developers may use jakarta.xml.ws.Dispatch APIs defined in Jakarta XML
 Web Services specification. This is a low level API that requires clients to
 construct messages or message payloads as XML and requires an intimate
 knowledge of the desired message or payload structure. This is useful in
@@ -614,7 +616,7 @@ level.
 An instance of jakarta.xml.ws.Dispatch can be obtained by invoking any one
 of the two createDispatch(...) methods on a Service interface. Details
 on Dispatch API's and its usage can be referenced at section 4.3 of the
-Jakarta XML Web Services specification
+Jakarta XML Web Services specification.
 
 ==== Jakarta XML Web Services Asynchronous Operations
 
@@ -622,7 +624,7 @@ Client developer may use asynchronous invocations as defined by the
 Jakarta XML Web Services specification. This supports asynchronous invocations
 through generated asynchronous methods on the Service Endpoint Interface
 (section 2.3.4 of Jakarta XML Web Services specification) and
-javax.xml.ws.Dispatch (section 4.3.3 of Jakarta XML Web Services specification)
+jakarta.xml.ws.Dispatch (section 4.3.3 of Jakarta XML Web Services specification)
 interface. There are two forms of asynchronous invocations in Jakarta XML Web
 Services – Polling and Callback.
 
@@ -632,22 +634,22 @@ Client asynchronous polling invocations must be supported by components
 running in Servlet container, EJB container and Application Client
 container, since any of these components can act as Jakarta XML Web Services
 clients. Client developers can either use the Service Endpoint Interface or
-javax.xml.ws.Dispatch to make asynchronous polling invocations. The
+jakarta.xml.ws.Dispatch to make asynchronous polling invocations. The
 usage must meet the requirements defined in section 2.3.4 of Jakarta XML Web
 Services specification for Service Endpoint Interface or section 4.3.3 of
-Jakarta XML Web Services specification for javax.xml.ws.Dispatch interface.
+Jakarta XML Web Services specification for jakarta.xml.ws.Dispatch interface.
 
 ===== Callback
 
 Client asynchronous callback invocations should only be supported by
 components running in EJB, Servlet container and Application Client
 container. Client developers can either use the Service Endpoint
-Interface or javax.xml.ws.Dispatch to implement asynchronous callback
+Interface or jakarta.xml.ws.Dispatch to implement asynchronous callback
 invocations. The callback handler must implement
-javax.xml.ws.AsyncHandler interface. The usage should meet the
+jakarta.xml.ws.AsyncHandler interface. The usage should meet the
 requirements defined in section 2.3.4 of Jakarta XML Web Services specification
 for Service Endpoint Interface or section 4.3.3 of Jakarta XML Web Services
-specification for javax.xml.ws.Dispatch interface.
+specification for jakarta.xml.ws.Dispatch interface.
 
 It will be the container implementers responsibility to insure that the
 client developer has access to java:comp/env JNDI context for that
@@ -679,11 +681,11 @@ If no propagated identity is provided for invoking the callback handler,
 then the handler executes under unauthenticated identity as defined by
 the container.
 
-The handleResponse() method of the javax.xml.ws.AsyncHandler executes in
+The handleResponse() method of the jakarta.xml.ws.AsyncHandler executes in
 an unspecified transaction context. If the handleResponse() method of
-the callback handler creates a transaction using the JTA UserTransaction
-interface then this transaction must be committed or rollbacked before
-the return of handleResponse() method.
+the callback handler creates a transaction using the Jakarta Transactions
+UserTransaction interface then this transaction must be committed or
+rollbacked before the return of handleResponse() method.
 
 Requirements for asynchronous callback invocations in the EJB container:
 
@@ -745,6 +747,7 @@ Table : Relationship between deployment descriptor elements and @MTOM
 
 [cols=",",]
 |===
+|Deployment Descriptor elements |@MTOM
 |<service-ref>/<port-component-ref>/<enable-mtom> |@MTOM.enabled
 |<service-ref>/<port-component-ref>/<mtom-threshold> |@MTOM.threshold
 |===
@@ -798,6 +801,7 @@ Table : Relationship between deployment descriptor elements and
 
 [cols=",",]
 |===
+|Deployment Descriptor elements |@Addressing
 |<service-ref>/<port-component-ref>/<addressing>/<enabled>
 |@Addressing.enabled
 
@@ -833,7 +837,7 @@ The jakarta.xml.ws.RespectBinding annotation or its corresponding
 jakarta.xml.ws.RespectBindingFeature web service feature is used to
 control whether a Jakarta XML Web Services implementation must respect/honor
 the contents of the wsdl:binding in the WSDL that is associated with the
-service. See 6.5.3 and 7.14.3 sections in Jakarta XML Web Services 2.2
+service. See 6.5.3 and 7.14.3 sections in the Jakarta XML Web Services
 specification.
 
 RespectBinding web service feature on the client can be enabled or
@@ -854,6 +858,7 @@ Table : Relationship between deployment descriptor elements and
 
 [cols=",",]
 |===
+|Deployment Descriptor elements |@RespectBinding
 |<service-ref>/<port-component-ref>/<respect-binding>/<enabled>
 |@RespectBinding.enabled
 |===

--- a/enterprise-ws-spec/src/main/asciidoc/ClientProgrammingModel.adoc
+++ b/enterprise-ws-spec/src/main/asciidoc/ClientProgrammingModel.adoc
@@ -3,11 +3,10 @@
 
 This chapter defines the client programming model of Web Services for
 Java EE. In general, the client programming model is covered in detail
-by the JAX-RPC or JAX-WS specification. This specification covers the
-use of the JAX-RPC or JAX-WS client programming model in a Java EE
-environment.
+by the Jakarta XML Web Services specification. This specification covers the
+use of the client programming model in a Jakarta EE environment.
 
-Differences between this specification and the JAX-RPC or JAX-WS
+Differences between this specification and the Jakarta XML Web Services
 specification will be noted in this style.
 
 [#anchor-19]
@@ -15,17 +14,17 @@ specification will be noted in this style.
 
 Clients of Web services are not limited to clients defined within this
 specification, however the client programming model for non-Web Services
-for Java EE clients is not specifically addressed by this specification.
+for Jakarta EE clients is not specifically addressed by this specification.
 In general, the WSDL definition of a Web service provides enough
-information for a non-Web Services for Java EE client to be built and
+information for a non-Web Services for Jakarta EE client to be built and
 run, but the programming model for that is undefined. The rest of this
-chapter covers the programming model for Web Services for Java EE
+chapter covers the programming model for Web Services for Jakarta EE
 clients. It makes no assumption on whether the Web service
 implementation invoked by the client is hosted by a Web Services for
-Java EE run-time or some external run-time.
+Jakarta EE run-time or some external run-time.
 
-A client uses the Web Services for Java EE run-time to access and invoke
-the methods of a Web service. A client can be any of the following: Java
+A client uses the Web Services for Jakarta EE run-time to access and invoke
+the methods of a Web service. A client can be any of the following: Jakarta
 EE application client, web component, EJB component, or another Web
 service.
 
@@ -38,25 +37,22 @@ persistent across multiple Web service method invocations. A client can
 treat the Web service implementation as stateless.
 
 A client accesses a Web service using a Service Endpoint Interface as
-defined by the JAX-RPC or JAX-WS specification. A reference to the Web
-service implementation should never be passed to another object. A
+defined by the Jakarta XML Web Services specification. A reference to the
+Web service implementation should never be passed to another object. A
 client should never access the Web service implementation directly.
 Doing so bypasses the container’s request processing which may open
 security holes or cause anomalous behavior.
 
 A client uses JNDI lookup to access a Service object that implements the
-Service Interface/Class as defined by the JAX-RPC and JAX-WS
+Service Interface/Class as defined by the Jakarta XML Web Services
 specification. The Service object is a factory used by the client to get
 a stub or proxy that implements the Service Endpoint Interface. The stub
 is the client representation of an instance of the Web service.
 
-The Service Interface can be a generic javax.xml.rpc.Service interface
-or a Generated Service Interface, which extends javax.xml.rpc.Service,
-as defined by JAX-RPC. With JAX-WS, the Service Class can be the generic
-javax.xml.ws.Service class or a Generated Service class, which extends
-javax.xml.ws.Service. Further references in this document to the Service
-Interface/Class refer to either the generic or generated version, unless
-noted otherwise.
+The Service Class can be the generic javax.xml.ws.Service class or a Generated
+Service class, which extends javax.xml.ws.Service. Further references in this
+document to the ServiceInterface/Class refer to either the generic or generated
+version, unless noted otherwise.
 
 The client has no control over the life cycle of the Web service
 implementation on the server. A client does not create or destroy
@@ -73,8 +69,8 @@ A client developer starts with the Service Endpoint Interface and
 Service Interface/Class. How a developer obtains these is out of scope,
 but includes having the Web service provider supply them or tools
 generate them from a WSDL definition supplied by the Web service
-provider. These tools operate according to the JAX-RPC or JAX-WS rules
-for WSDL->Java mapping. A client developer does not need to generate
+provider. These tools operate according to the Jakarta XML Web Services
+rules for WSDL->Java mapping. A client developer does not need to generate
 stubs during development, nor are they encouraged to do so. The client
 should use the interfaces, and not the stubs. Stubs will be generated
 during deployment and will be specific to the vendor’s run-time the
@@ -86,11 +82,9 @@ declares it along with the required Service Interface/Class in a Web
 service client deployment descriptor. The client should use the Service
 interfaces/classes, and not the stubs.
 
-The Service Interface methods can be categorized into two groups:
-stub/proxy and DII. The stub/proxy methods provide both service specific
+The Service Interface stub/proxy methods provide both service specific
 (client requires WSDL knowledge) and service agnostic (does not require
-WSDL knowledge) access to Ports. In JAX-RPC, DII methods are used when a
-client needs dynamic, non-stub based communication with the Web service.
+WSDL knowledge) access to Ports.
 
 A client can use the stub/proxy methods of the Service Interface/Class
 to get a Port stub or dynamic proxy. The WSDL specific methods can be
@@ -99,14 +93,14 @@ client developer. The WSDL agnostic methods must be used if the client
 developer has a partial WSDL definition that only contains only the
 portType and bindings.
 
-With JAX-WS, a client can also use the Service Class to work at the XML
-message level using Dispatch APIs. Additionally a client can also make
-asynchronous invocations using both stubs and Dispatch APIs.
+With Jakarta XML Web Services, a client can also use the Service Class to work
+at the XML message level using Dispatch APIs. Additionally a client can also
+make asynchronous invocations using both stubs and Dispatch APIs.
 
 === Specification
 
-The following sections define the requirements for Java EE product
-providers that implement Web Services for Java EE and developers for
+The following sections define the requirements for Jakarta EE product
+providers that implement Web Services for Jakarta EE and developers for
 creating applications that run in such an environment.
 
 [#anchor-26]
@@ -137,11 +131,10 @@ Service abf = (Service)ic.lookup(
 "java:comp/env/service/AddressBookService");
 
 In the above example, the container must ensure that an implementation
-of the generic Service Interface, javax.xml.rpc.Service or generic
-Service class, javax.xml.ws.Service, is bound in the JNDI name space at
-a location specified by the developer. A similar code fragment is used
-for access to an object that implements a Generated Service Interface
-such as AddressBookService.
+of the generic Service Interface, jakarta.xml.ws.Service, is bound in the
+JNDI name space at a location specified by the developer. A similar code
+fragment is used for access to an object that implements a Generated Service
+Interface such as AddressBookService.
 
 InitialContext ic = new InitialContext ();
 
@@ -149,27 +142,27 @@ AddressBookService abf = (AddressBookService)ic.lookup(
 
 "java:comp/env/service/AddressBookService");
 
-A Java EE product provider is required to provide Service lookup support
+A Jakarta EE product provider is required to provide Service lookup support
 in the web, EJB, and application client containers.
 
-==== javax.xml.ws.WebServiceRef annotation
+==== jakarta.xml.ws.WebServiceRef annotation
 
-With JAX-WS, client developer may use the javax.xml.ws.WebServiceRef
-annotation to denote a reference to a Service or a Service endpoint.
-Lookups using JNDI mechanism for both Service or Service endpoint can
-also be used under JAX-WS. Complete definition of
-javax.xml.ws.WebServiceRef annotation is defined in section 7.9 of
-JAX-WS specification. The containers must ensure that the use of this
-annotation is supported.
+With Jakarta XML Web Services, client developer may use the 
+jakarta.xml.ws.WebServiceRef annotation to denote a reference to a Service
+or a Service endpoint. Lookups using JNDI mechanism for both Service or
+Service endpoint can also be used under Jakarta XML Web Services. Complete
+definition of jakarta.xml.ws.WebServiceRef annotation is defined in the
+Jakarta XML Web Services specification. The containers must ensure that the
+use of this annotation is supported.
 
-The annotations (for example, _@javax.xml.ws.soap.Addressing_) annotated
-with meta-annotation _javax.xml.ws.spi.WebServiceFeatureAnnotation_ can
+The annotations (for example, _@jakarta.xml.ws.soap.Addressing_) annotated
+with meta-annotation _jakarta.xml.ws.spi.WebServiceFeatureAnnotation_ can
 be used in conjunction with _@WebServiceRef_. The created reference MUST
-be configured with annotation's web service feature. If a JAX-WS
-implementation encounters an unsupported or unrecognized feature
-annotation, an error must be given. JAX-WS doesn't define any standard
-portable web service feature for Service references. But it defines
-_@Addressing_, _@MTOM_, _@RespectBinding_ annotations for SEI proxy
+be configured with annotation's web service feature. If a Jakarta XML Web
+Services implementation encounters an unsupported or unrecognized feature
+annotation, an error must be given. Jakarta XML Web Services doesn't define
+any standard portable web service feature for Service references. But it
+defines _@Addressing_, _@MTOM_, _@RespectBinding_ annotations for SEI proxy
 references.
 
 By using a web service feature annotation explicitly along with a
@@ -202,17 +195,17 @@ AddressBookPort port;
 Address address = port.getAddress(“John Doe”);
 
 A declared reference can be resolved using lookup functionality
-specified by JAX-WS specification. The following example illustrates the
-use of this annotation for looking up a Service:
+specified by Jakarta XML Web Services specification. The following example
+illustrates the use of this annotation for looking up a Service:
 
 _@WebServiceRef(lookup="java:comp/env/service/AddressBookService"_)
 
 AddressBookService other;
 
-javax.jws.HandlerChain annotation can be used with this annotation to
+jakarta.jws.HandlerChain annotation can be used with this annotation to
 specify handlers on these client side references. More information on
-the HandlerChain annotation can be found in JSR-181 specification and
-also in Chapter 6 of this specification.
+the HandlerChain annotation can be found in Jakarta Web Services Metadata
+specification and also in Chapter 6 of this specification.
 
 If wsdlLocation attribute of WebServiceRef annotation is specified, it
 is always relative to the root of the module. HTTP URL can also be
@@ -221,26 +214,25 @@ specified here. The <wsdl-file> element in client deployment descriptor
 annotation. If there is no <wsdl-file> element or wsdlLocation specified
 in the annotation, then the wsdlLocation attribute of @WebServiceClient
 annotation on the generated Service class needs to be consulted.
-(section 7.5 of JAX-WS specification).
+(section 7.5 of Jakarta XML Web Services specification).
 
 For co-located clients (where the client and the server are in the same
-Java EE application unit) with generated Service class, the location of
+Jakarta EE application unit) with generated Service class, the location of
 the final WSDL document is resolved by comparing the Service name on the
 @WebServiceClient annotation on the the generated Service to the Service
-names of all the deployed port components in the Java EE application
+names of all the deployed port components in the Jakarta EE application
 unit. This default behavior can be overridden using the
 <port-component-link> deployment descriptor element. Refer to client
 deployment descriptor schema Section 7.2.5
 
 If the name attribute is not specified in this annotation then default
-naming rules apply as specified in the Java EE specification. (section
-EE.5.2.3)
+naming rules apply as specified in the Jakarta EE specification.
 
 The following table summarizes the relationship between the deployment
 descriptors for <service-ref> and member attributes of this annotation .
 
 * Table 1 Relationship between the deployment descriptor elements and
-javax.xml.ws.WebServiceRef annotation
+jakarta.xml.ws.WebServiceRef annotation
 
 [cols=",",]
 |===
@@ -260,8 +252,7 @@ OR
 Endpoint.class
 
 The type attribute is implied when this annotation is used on a field.
-Similar to @Resource annotation in JSR-250 Common Annotations for Java
-Platform
+Similar to @Resource annotation in Jakarta Annotations
 
 |<service-ref>/<port-component-ref>/<service-endpoint-interface>
 |@WebServiceRef.type when @WebServiceRef.value is a Service class.
@@ -282,32 +273,30 @@ If the instances are accessed by multiple threads, usual synchronization
 techniques can be used to support multiple threads.
 
 For declaring multiple references to Web services on a single class
-javax.xml.ws.WebServiceRefs annotation may be used. Complete definition
-of javax.xml.ws.WebServiceRefs annotation is defined in section 7.10 of
-JAX-WS specification. The containers must ensure that the use of this
-annotation is supported.
+jakarta.xml.ws.WebServiceRefs annotation may be used. Complete definition
+of jakarta.xml.ws.WebServiceRefs annotation is defined in section 7.10 of
+Jakarta XML Web Services specification. The containers must ensure that the
+use of this annotation is supported.
 
 ==== Port Lookup
 
-With JAX-WS, the client developer can also use JNDI lookups for a Port.
-This is analogous to using the javax.xml.ws.WebServiceRef annotation for
-Service endpoint. The client side deployment descriptor has been
-modified to introduce a new optional element <service-ref-type> that
+With Jakarta XML Web Services, the client developer can also use JNDI lookups
+for a Port. This is analogous to using the javax.xml.ws.WebServiceRef
+annotation for Service endpoint. The client side deployment descriptor has
+been modified to introduce a new optional element <service-ref-type> that
 declares the type of <service-ref> returned when a dependency injection
 or JNDI lookup is done. If this element is not specified in the
 deployment descriptor, then the type of <service-ref> is always a
 Service class or a generated Service class.
 
-A Java EE product provider is required to provide Port lookup support in
+A Jakarta EE product provider is required to provide Port lookup support in
 the web, EJB, and application client containers.
 
 ==== Service API
 
-The Service API is used by a client to get a stub or dynamic proxy or a
-DII Call object for a Port. A container provider is required to support
-all methods of the Service interface/class except for the
-getHandlerRegistry() and getTypeMappingRegistry() methods as described
-in sections link:#anchor-27[4.2.4.8] and link:#anchor-28[4.2.4.9].
+The Service API is used by a client to get a stub or dynamic proxy for a Port.
+A container provider is required to support all methods of the Service
+interface/class.
 
 A client developer must declare the Service Interface/Class type used by
 the application in the client deployment descriptor. The Service
@@ -316,16 +305,7 @@ Interface/Class represents the deployed WSDL of a service.
 [#anchor-29]
 ===== Stub/proxy access
 
-With JAX-RPC, the client may use the following Service Interface methods
-to obtain a static stub or dynamic proxy for a Web service:
-
-java.rmi.Remote getPort(QName portName, Class serviceEndpointInterface)
-throws ServiceException;
-
-java.rmi.Remote getPort(java.lang.Class serviceEndpointInterface) throws
-ServiceException;
-
-With JAX-WS, the client may use the following Service class methods to
+The client may use the following Service class methods to
 obtain a proxy for a Web service:
 
 <T> T getPort(QName portName, Class<T> serviceEndpointInterface);
@@ -369,45 +349,15 @@ interface argument to a port is not declared in the client deployment
 descriptor, the container may provide a default resolution capability or
 throw a ServiceException.
 
-===== Dynamic Port access
-
-With JAX-RPC, a client may use the following DII methods of a Service
-Interface located by a JNDI lookup of the client’s environment to obtain
-a Call object:
-
-Call createCall() throws ServiceException;
-
-Call createCall(QName portName) throws ServiceException;
-
-Call createCall(QName portName, String operationName) throws
-ServiceException;
-
-Call createCall(QName portName, QName operationName) throws
-ServiceException;
-
-Call[] getCalls(QName portName) throws ServiceException;
-
-A DII Call object may or may not be pre-configured for use depending on
-the method used to obtain it. See the JAX-RPC specification for details.
-
-These methods are not supported in JAX-WS. JAX-WS provides Dispatch APIs
-to enable the client to operate at XML message level. See section 4.2.6.
-
 ===== ServiceFactory
 
-Use of the JAX-RPC ServiceFactory class is not recommended in a Web
-Services for Java EE product. A Web Services for Java EE client must
-obtain a Service Interface/Class using JNDI lookup as described in
-section link:#anchor-26[4.2.1]. Container providers are not required to
-support managed Service instances created from a ServiceFactory.
-
-ServiceFactory class has been removed from JAX-WS. It has been replaced
-by two static methods Service.create(QName serviceName)and
+ServiceFactory class has been removed from Jakarta XML Web Services. It has
+been replaced by two static methods Service.create(QName serviceName) and
 Service.create(URL wsdlLocation, QName serviceName) for creating Service
 instances. These methods rely on specific implementations of
-ServiceDelegate Class in any JAX-WS compliant implementation. The use of
-these static methods is not recommended in a Web Services for Java EE
-product. A Web Services for Java EE client must obtain a Service
+ServiceDelegate Class in any Jakarta XML Web Services compliant implementation.
+The use of these static methods is not recommended in a Web Services for
+Jakarta EE product. A Web Services for Jakarta EE client must obtain a Service
 Interface/Class using JNDI lookup as described in section
 link:#anchor-26[4.2.1]. Container providers are not required to support
 managed Service instances created using these methods.
@@ -415,14 +365,12 @@ managed Service instances created using these methods.
 [#anchor-31]
 ===== Service method use with full WSDL
 
-A client developer may use all methods of the Service Interface (except
-as described in sections link:#anchor-27[4.2.4.8] and
-link:#anchor-28[4.2.4.9]) or class if a full WSDL description and
-JAX-RPC mapping file are declared in the client deployment descriptor.
-If JAX-WS is used, mapping file is not required because all of the data
-binding in JAX-WS is done according to the JAXB specification. The port
-address location attribute of a port using a SOAP/HTTP binding must
-begin with http: or https:.
+A client developer may use all methods of the Service Interface or class if a
+full WSDL description is declared in the client deployment descriptor.  A
+mapping file is not required because all of the data binding in Jakarta XML
+Web Services is done according to the JAXB specification. The port address
+location attribute of a port using a SOAP/HTTP binding must begin with http:
+or https:.
 
 If a client developer uses the getPort(SEI) method of a Service
 Interface/Class and the WSDL supports multiple ports the SEI could be
@@ -432,22 +380,7 @@ preference by ordering the ports in the service-ref’s WSDL document.
 [#anchor-32]
 ===== Service method use with partial WSDL
 
-With JAX-RPC, a client developer may use the following methods of the
-Service Interface if a partial WSDL definition is declared in the client
-deployment descriptor:
-
-Call createCall() throws ServiceException;
-
-java.rmi.Remote getPort(java.lang.Class serviceEndpointInterface) throws
-ServiceException;
-
-javax.xml.namespace.QName getServiceName();
-
-java.util.Iterator getPorts() throws ServiceException;
-
-java.net.URL getWSDLDocumentLocation()
-
-If JAX-WS is used, client developer may use the following methods of the
+A client developer may use the following methods of the
 Service class:
 
 <T> T getPort(java.lang.Class(T) serviceEndpointInterface);
@@ -499,11 +432,9 @@ JAXBContext context, Service.Mode mode,
 WebServiceFeature... features);
 
 A partial WSDL definition is defined as a fully specified WSDL document
-which contains no service or port elements. The JAX-RPC mapping file
-specified by the developer will not include a service-interface-mapping
-in this case. If JAX-WS is used, mapping file is not required and
-ignored if specified, because all of the data binding in JAX-WS is done
-according to the JAXB specification
+which contains no service or port elements. A mapping file is not required
+and ignored if specified, because all of the data binding in Jakarta XML Web
+Services is done according to the JAXB specification.
 
 Use of other methods of the Service Interface/Class is not recommended
 when a developer specifies a partial WSDL definition. The behavior of
@@ -515,16 +446,7 @@ method.
 
 ===== Service method use with no WSDL
 
-With JAX-RPC, a client developer may use the following methods of the
-Service Interface if no WSDL definition is specified in the client
-deployment descriptor:
-
-Call createCall() throws ServiceException;
-
-If the wsdl-file is not specified in the deployment descriptor, the
-jaxrpc-mapping-file must not be specified.
-
-With JAX-WS, a client developer may use the following methods of the
+A client developer may use the following methods of the
 Service class if no WSDL definition is specified in the client
 deployment descriptor:
 
@@ -576,44 +498,8 @@ recommended. Their behavior is unspecified.
 The following table summarizes the behavior of the methods of the
 Service Interface under various deployment configurations.
 
-* Table 2 Service Interface method behavior with JAX-RPC
 
-[cols=",,,",]
-|===
-|Call createCall() |Normal |Normal |Normal
-
-|Call createCall(QName port) |Normal |Unspecified |Unspecified
-
-|Call createCall(QName port, QName operation) |Normal |Unspecified
-|Unspecified
-
-|Call createCall(QName port, String operation) |Normal |Unspecified
-|Unspecified
-
-|Call[] getCalls(QName port) |Normal |Unspecified |Unspecified
-
-|HandlerRegistry getHandlerRegistry() |Exception^1^ |Exception^1^
-|Exception^1^
-
-|Remote getPort(Class SEI) |Normal |Normal |Unspecified
-
-|Remote getPort(QName port, Class SEI) |Normal |Unspecified |Unspecified
-
-|Iterator getPorts() |Bound ports |Bound ports |Unspecified
-
-|QName getServiceName() |Bound service name |Bound service name
-|Unspecified
-
-|TypeMappingRegistry getTypeMappingRegistry() |Exception^1^
-|Exception^1^ |Exception^1^
-
-|URL getWSDLDocumentLocation() |Bound WSDL location |Bound WSDL location
-|Unspecified
-|===
-
-^1^See sections link:#anchor-27[4.2.4.8] and link:#anchor-28[4.2.4.9].
-
-* Table 3 Service class method behavior with JAX-WS
+* Table 2 Service class method behavior with Jakarta XML Web Services
 
 [cols=",,,",]
 |===
@@ -673,23 +559,6 @@ features) |Normal |Unspecified |Unspecified
 features) |Normal |Unspecified |Unspecified
 |===
 
-[#anchor-27]
-===== Handlers
-
-With JAX-RPC components should not use the getHandlerRegistry() method.
-A container provider must throw a
-java.lang.UnsupportedOperationException from the getHandlerRegistry()
-method of the Service Interface. Handler support is documented in
-Chapter link:#anchor-33[6] link:#anchor-33[Handlers].
-
-[#anchor-28]
-===== Type Mapping
-
-With JAX-RPC components should not use the getTypeMappingRegistry()
-method. A container provider must throw a
-java.lang.UnsupportedOperationException from the
-getTypeMappingRegistry() method of the Service Interface.
-
 [#anchor-30]
 ==== Port Stub and Dynamic Proxy
 
@@ -709,76 +578,64 @@ or the same Port instance for multiple invocations.
 
 ===== Type narrowing
 
-In JAX-RPC, although the stub and dynamic proxy classes are considered
-Remote objects, a client is not required to use
-PortableRemoteObject.narrow(…). However, clients are encouraged to use
-PortableRemoteObject.narrow(…) to prevent confusion with client use of
-other Remote objects.
-
-In JAX-WS, proxy classes are not Remote Objects. Hence the use of
+Proxy classes are not Remote Objects. Hence the use of
 PortableRemoteObject.narrow(…) is not required.
 
 [#anchor-34]
-==== JAX_RPC and JAX-WS Properties
+==== Jakarta XML Web Services Properties
 
-The Java EE container environment provides a broader set of operational
+The Jakarta EE container environment provides a broader set of operational
 characteristics and constraints for supporting the Stub/proxy properties
-defined within JAX-RPC or JAX-WS. While support of standard properties
-for Stub and Call (only in JAX-RPC) objects is required, their use may
-not work in all cases in a Java EE environment.
+defined within Jakarta XML Web Services. While support of standard properties
+for Stub objects is required, their use may not work in all cases in a Jakarta
+EE environment.
 
-The following JAX-RPC properties are not recommended for use in a
-managed context defined by this specification:
+The following Jakarta XML Web Services properties are not recommended for use
+in a managed context defined by this specification:
 
-* javax.xml.rpc.security.auth.username
-* javax.xml.rpc.security.auth.password
-
-The following JAX-WS properties are not recommended for use in a managed
-context defined by this specification:
-
-* javax.xml.ws.security.auth.username
-* javax.xml.ws.security.auth.password
+* jakarta.xml.ws.security.auth.username
+* jakarta.xml.ws.security.auth.password
 
 ===== Required properties
 
 A container provider is required to support the
-javax.xml.rpc.service.endpoint.address property in JAX-RPC and
-javax.xml.ws.service.endpoint.address property in JAX-WS to allow
+javax.xml.ws.service.endpoint.address property to allow
 components to dynamically redirect a Stub/proxy to a different URI.
 
-==== JAX-WS Dispatch APIs
+==== Jakarta XML Web Services Dispatch APIs
 
-Client developers may use javax.xml.ws.Dispatch APIs defined in JAX-WS
-specification. This is a low level API that requires clients to
+Client developers may use javax.xml.ws.Dispatch APIs defined in Jakarta XML
+Web Services specification. This is a low level API that requires clients to
 construct messages or message payloads as XML and requires an intimate
 knowledge of the desired message or payload structure. This is useful in
 those situations where the client wants to operate at the XML message
 level.
 
-An instance of javax.xml.ws.Dispatch can be obtained by invoking any one
+An instance of jakarta.xml.ws.Dispatch can be obtained by invoking any one
 of the two createDispatch(...) methods on a Service interface. Details
 on Dispatch API's and its usage can be referenced at section 4.3 of the
-JAX-WS specification
+Jakarta XML Web Services specification
 
-==== JAX-WS Asynchronous Operations
+==== Jakarta XML Web Services Asynchronous Operations
 
 Client developer may use asynchronous invocations as defined by the
-JAX-WS specification. JAX-WS supports asynchronous invocations through
-generated asynchronous methods on the Service Endpoint Interface
-(section 2.3.4 of JAX-WS specification) and javax.xml.ws.Dispatch
-(section 4.3.3 of JAX-WS specification) interface. There are two forms
-of asynchronous invocations in JAX-WS – Polling and Callback.
+Jakarta XML Web Services specification. This supports asynchronous invocations
+through generated asynchronous methods on the Service Endpoint Interface
+(section 2.3.4 of Jakarta XML Web Services specification) and
+javax.xml.ws.Dispatch (section 4.3.3 of Jakarta XML Web Services specification)
+interface. There are two forms of asynchronous invocations in Jakarta XML Web
+Services – Polling and Callback.
 
 ===== Polling
 
 Client asynchronous polling invocations must be supported by components
 running in Servlet container, EJB container and Application Client
-container, since any of these components can act as JAX-WS clients.
-Client developers can either use the Service Endpoint Interface or
+container, since any of these components can act as Jakarta XML Web Services
+clients. Client developers can either use the Service Endpoint Interface or
 javax.xml.ws.Dispatch to make asynchronous polling invocations. The
-usage must meet the requirements defined in section 2.3.4 of JAX-WS
-specification for Service Endpoint Interface or section 4.3.3 of JAX-WS
-specification for javax.xml.ws.Dispatch interface.
+usage must meet the requirements defined in section 2.3.4 of Jakarta XML Web
+Services specification for Service Endpoint Interface or section 4.3.3 of
+Jakarta XML Web Services specification for javax.xml.ws.Dispatch interface.
 
 ===== Callback
 
@@ -788,9 +645,9 @@ container. Client developers can either use the Service Endpoint
 Interface or javax.xml.ws.Dispatch to implement asynchronous callback
 invocations. The callback handler must implement
 javax.xml.ws.AsyncHandler interface. The usage should meet the
-requirements defined in section 2.3.4 of JAX-WS specification for
-Service Endpoint Interface or section 4.3.3 of JAX-WS specification for
-javax.xml.ws.Dispatch interface.
+requirements defined in section 2.3.4 of Jakarta XML Web Services specification
+for Service Endpoint Interface or section 4.3.3 of Jakarta XML Web Services
+specification for javax.xml.ws.Dispatch interface.
 
 It will be the container implementers responsibility to insure that the
 client developer has access to java:comp/env JNDI context for that
@@ -853,23 +710,23 @@ is accessed from within the handler.
 * It is recommended that the developer not cache the HttpSession and
 HttpRequest objects from the Servlet in the callback handler.
 
-==== JAX-RPC and JAX-WS Interoperability
+==== JAX-RPC and Jakarta XML Web Services Interoperability
 
-Interoperability between a JAX-RPC client and JAX-WS endpoint (or
-vice-versa) is governed by the requirements defined by the WS-I Basic
-Profile 1.0. As long as both the client and the server adhere to these
-requirements, they should be able to interoperate.
+Interoperability between a JAX-RPC client and Jakarta XML Web Services
+endpoint (or vice-versa) is governed by the requirements defined by the
+WS-I Basic Profile 1.0. As long as both the client and the server adhere
+to these requirements, they should be able to interoperate.
 
 ==== MTOM/XOP support
 
-JAX-WS compliant implementations are required to support MTOM (Message
-Transmission Optimization Mechanism)/XOP (XML-binary Optimized
+Jakarta XML Web Services compliant implementations are required to support
+MTOM (Message Transmission Optimization Mechanism)/XOP (XML-binary Optimized
 Packaging) specifications from W3C. Refer to sections 6.5.2, 7.14.2, and
-10.4.1.1 of JAX-WS specification. Support for SOAP MTOM/XOP mechanism
-for optimizing transmission of binary data types is provided by JAXB
-which is the data binding for JAX-WS. JAX-WS provides the MIME
-processing required to enable JAXB to serialize and deserialize MIME
-based MTOM/XOP packages.
+10.4.1.1 of Jakarta XML Web Services specification. Support for SOAP MTOM/XOP
+mechanism for optimizing transmission of binary data types is provided by JAXB
+which is the data binding for Jakarta XML Web Services. Jakarta XML Web
+Services provides the MIME processing required to enable JAXB to serialize and
+deserialize MIME based MTOM/XOP packages.
 
 SOAP MTOM/XOP mechanism on the client can be enabled or disabled by any
 one of the following ways:
@@ -892,15 +749,6 @@ Table : Relationship between deployment descriptor elements and @MTOM
 |<service-ref>/<port-component-ref>/<mtom-threshold> |@MTOM.threshold
 |===
 
-==== JAX-RPC Custom Serializers / Deserializers
-
-The use of JAX-RPC custom serializers / deserializers is out of scope
-for this version of the specification. JAX-RPC customer serializers /
-deserializers are not portable across Web Services for Java EE providers
-and are therefore not included as part of the portable deployment unit.
-It is expected that vendors will provide proprietary solutions to this
-problem until it has been addressed by a future version of JAX-RPC.
-
 ==== Packaging
 
 The developer is responsible for packaging, either by containment or
@@ -908,30 +756,27 @@ reference (i.e. by using the MANIFEST ClassPath to refer to other JAR
 files that contain the required classes), the class files for each Web
 service including the: Service Endpoint Interface classes, Generated
 Service Interface class (if used), and their dependent classes. The
-following files must also be packaged in the module: WSDL files, JAX-RPC
-Mapping files (not required with JAX-WS), and a Web services client
-deployment descriptor (not required with JAX-WS if annotations are used)
-in a Java EE module. The location of the Web services client deployment
+following files must also be packaged in the module: WSDL files and a Web 
+services client deployment descriptor (not required if annotations are used)
+in a Jakarta EE module. The location of the Web services client deployment
 descriptor in the module is module specific. WSDL files are located
 relative to the root of the module and are typically located in the wsdl
 directory that is co-located with the module deployment descriptor or a
-subdirectory of it. JAX-RPC Mapping Files (not required with JAX-WS) are
-located relative to the root of the module and are typically co-located
-with the WSDL file. The developer must not package generated stubs.
+subdirectory of it. The developer must not package generated stubs.
 
-JAX-WS requires support for a OASIS XML Catalogs 1.1 specification to be
-used when resolving any Web service document that is part of the
-description of a Web service, specifically WSDL and XML Schema
-documents. Refer to section 4.4 of JAX-WS specification. The catalog
-file jax-ws-catalog.xml must be co-located with the module deployment
+Jakarta XML Web Services requires support for a OASIS XML Catalogs 1.1
+specification to be used when resolving any Web service document that is
+part of the description of a Web service, specifically WSDL and XML Schema
+documents. Refer to section 4.4 of Jakarta XML Web Services specification. The
+catalog file jax-ws-catalog.xml must be co-located with the module deployment
 descriptor (WEB-INF/jax-ws-catalog.xml for web modules and
 META-INF/jax-ws-catalog.xml for the rest).
 
 ==== Web Services Addressing Support
 
-JAX-WS clients are required to support Web Services Addressing 1.0 -
-Core, Web Services Addressing 1.0 - Soap Binding, and Web Services
-Addressing 1.0 - Metadata.
+Jakarta XML Web Services clients are required to support Web Services
+Addressing 1.0 - Core, Web Services Addressing 1.0 - Soap Binding, and Web
+Services Addressing 1.0 - Metadata.
 
 Web Service Addressing requirements for a client can be specified by any
 one of the following ways:
@@ -963,32 +808,33 @@ Table : Relationship between deployment descriptor elements and
 |@Addressing.responses
 |===
 
-JAX-WS specifies an abstract javax.xml.ws.EndpointReference that
-represents a remote reference to a web service endpoint.
-javax.xml.ws.addressing.W3CEndpointReference class is a concrete
+Jakarta XML Web Services specifies an abstract jakarta.xml.ws.EndpointReference
+that represents a remote reference to a web service endpoint.
+jakarta.xml.ws.addressing.W3CEndpointReference class is a concrete
 EndpointReference implementation for WS-Addressing 1.0 - Core addressing
 version. Client applications can use an EndpointReference to get a port
-for an SEI using the getPort methods on javax.xml.ws.Service class. Also
+for an SEI using the getPort methods on jakarta.xml.ws.Service class. Also
 these EndpointReference objects can appear as SEI method parameters or
 return type and can be passed across the applications.
 
 A port's EndpointReference can be got using its
-javax.xml.ws.BindingProvider's getEndpointReference method.
+jakarta.xml.ws.BindingProvider's getEndpointReference method.
 Occasionally, it is necessary for one application component to create an
 EndpointReference for another web service endpoint. The
 W3CEndpointReferenceBuilder class provides a standard API for creating
 W3CEndpointReference instances for web service endpoints. When creating
-a W3CEndpointReference for an endpoint published by the same Java EE
-application, a JAX-WS runtime must fill the address(if not set by the
-application) of the endpoint using its service and port names.
+a W3CEndpointReference for an endpoint published by the same Jakarta EE
+application, a Jakarta XML Web Services runtime must fill the address (if
+not set by the application) of the endpoint using its service and port names.
 
 ==== Respect Binding Support
 
-The javax.xml.ws.RespectBinding annotation or its corresponding
-javax.xml.ws.RespectBindingFeature web service feature is used to
-control whether a JAX-WS implementation must respect/honor the contents
-of the wsdl:binding in the WSDL that is associated with the service. See
-6.5.3 and 7.14.3 sections in JAX-WS 2.2 specification.
+The jakarta.xml.ws.RespectBinding annotation or its corresponding
+jakarta.xml.ws.RespectBindingFeature web service feature is used to
+control whether a Jakarta XML Web Services implementation must respect/honor
+the contents of the wsdl:binding in the WSDL that is associated with the
+service. See 6.5.3 and 7.14.3 sections in Jakarta XML Web Services 2.2
+specification.
 
 RespectBinding web service feature on the client can be enabled or
 disabled by any one of the following ways:

--- a/enterprise-ws-spec/src/main/asciidoc/DeploymentDescriptors.adoc
+++ b/enterprise-ws-spec/src/main/asciidoc/DeploymentDescriptors.adoc
@@ -190,7 +190,6 @@ every webservice-description wsdl-file with the correct port address
 attribute value to access the service.
 * the value of the port address attribute for deployed services.
 
-[#section7.2.5]
 ==== Web Services Deployment Descriptor XML Schema
 
 The XML Schema for the Web service deployment descriptor is described at
@@ -323,6 +322,7 @@ a vendor to resolve the binding, they may be generated. The deployer is
 also responsible for providing deploy time binding information to
 resolve port access declared by the port-component-ref element.
 
+[#section725]
 ==== Web Services Client Service Reference XML Schema
 
 [#anchor-74]##This section defines the XML Schema for the service-ref at

--- a/enterprise-ws-spec/src/main/asciidoc/DeploymentDescriptors.adoc
+++ b/enterprise-ws-spec/src/main/asciidoc/DeploymentDescriptors.adoc
@@ -190,6 +190,7 @@ every webservice-description wsdl-file with the correct port address
 attribute value to access the service.
 * the value of the port address attribute for deployed services.
 
+[#section7.2.5]
 ==== Web Services Deployment Descriptor XML Schema
 
 The XML Schema for the Web service deployment descriptor is described at

--- a/enterprise-ws-spec/src/main/asciidoc/Introduction.adoc
+++ b/enterprise-ws-spec/src/main/asciidoc/Introduction.adoc
@@ -22,7 +22,8 @@ implementations deployed into Jakarta EE application servers
 
 This specification assumes that the reader is familiar with the Jakarta EE
 platform and specifications. It also assumes that the reader is familiar
-with Web services, specifically the JAX-WS Specification and WSDL documents.
+with Web services, specifically the Jakarta XML Web Services Specification
+and WSDL documents.
 
 === Acknowledgments
 

--- a/enterprise-ws-spec/src/main/asciidoc/Introduction.adoc
+++ b/enterprise-ws-spec/src/main/asciidoc/Introduction.adoc
@@ -78,11 +78,11 @@ document conventions used by other Jakarta EE specifications.
 The regular Times font is used for information that is prescriptive by
 this specification.
 
-The italic Times font is used for paragraphs that contain descriptive
+The _italic Times font_ is used for paragraphs that contain descriptive
 information, such as notes describing typical use, or notes clarifying
 the text with prescriptive specification.
 
-The Courier font is used for code examples.
+The `Courier font` is used for code examples.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this

--- a/enterprise-ws-spec/src/main/asciidoc/Introduction.adoc
+++ b/enterprise-ws-spec/src/main/asciidoc/Introduction.adoc
@@ -1,29 +1,28 @@
 == Introduction
 
-This specification defines the Web Services for Java EE (WSEE)
-architecture. This is a service architecture that leverages the Java EE
+This specification defines the Web Services for Jakarta EE (WSEE)
+architecture. This is a service architecture that leverages the Jakarta EE
 component architecture to provide a client and server programming model
 which is portable and interoperable across application servers, provides
-a scalable secure environment, and yet is familiar to Java EE
+a scalable secure environment, and yet is familiar to Jakarta EE
 developers.
 
 === Target Audience
 
 This specification is intended to be used by:
 
-* Java EE Vendors implementing support for Web services compliant with
+* Jakarta EE Vendors implementing support for Web services compliant with
 this specification
-* Developers of Web service implementations to be deployed into Java EE
+* Developers of Web service implementations to be deployed into Jakarta EE
 application servers
-* Developers of Web service clients to be deployed into Java EE
+* Developers of Web service clients to be deployed into Jakarta EE
 application servers
 * Developers of Web service clients that access Web service
-implementations deployed into Java EE application servers
+implementations deployed into Jakarta EE application servers
 
-This specification assumes that the reader is familiar with the Java EE
+This specification assumes that the reader is familiar with the Jakarta EE
 platform and specifications. It also assumes that the reader is familiar
-with Web services, specifically the JAX-RPC and JAX-WS Specification and
-WSDL documents.
+with Web services, specifically the JAX-WS Specification and WSDL documents.
 
 === Acknowledgments
 
@@ -61,9 +60,9 @@ release.
 === Specification Organization
 
 The next two chapters of this specification outline the requirements and
-conceptual architecture for Web services support in Java EE
+conceptual architecture for Web services support in Jakarta EE
 environments. Each of the major integration points for Web services in
-Java EE, the client model, the server model, the deployment model, WSDL
+Jakarta EE, the client model, the server model, the deployment model, WSDL
 bindings, and security have their own chapter. Each of these chapters
 consists of two topics: Concepts and Specification. The concepts section
 discusses how Web services are used, issues, considerations, and the
@@ -72,8 +71,8 @@ defines what implementers of this specification must support.
 
 === Document conventions.
 
-In the interest of consistency, this specification follows the document
-conventions used by the Enterprise JavaBeans specification.
+In the interest of consistency, this specification attempts to follow the
+document conventions used by other Jakarta EE specifications.
 
 The regular Times font is used for information that is prescriptive by
 this specification.

--- a/enterprise-ws-spec/src/main/asciidoc/Objectives.adoc
+++ b/enterprise-ws-spec/src/main/asciidoc/Objectives.adoc
@@ -26,7 +26,7 @@ this into a Jakarta EE application server.
 === Client Model Goals
 
 The client programming model should be conformant and compatible with
-the client programming model defined by JAX-WS.
+the client programming model defined by Jakarta XML Web Services.
 
 Additional goals for the client programming model are to ensure that:
 
@@ -61,11 +61,11 @@ defined requirements to ensure that it does not compromise the integrity
 of the application server.
 * This specification defines the Jakarta EE container based (Web and EJB)
 runtime such that it is consistent with the programming model defined by
-the JAX-WS specification.
+the Jakarta XML Web Services specification.
 * Support mapping and dispatching SOAP 1.1 or 1.2 requests to methods on
-Jakarta EE Stateless or Singleton(only JAX-WS) Session Beans.
+Jakarta EE Stateless or Singleton Session Beans.
 * Support mapping and dispatching SOAP 1.1 or 1.2 requests to methods on
-JAX-WS Service Endpoint classes in the Web Container.
+Jakarta XML Web Services Service Endpoint classes in the Web Container.
 
 === Service Deployment Goals
 

--- a/enterprise-ws-spec/src/main/asciidoc/Objectives.adoc
+++ b/enterprise-ws-spec/src/main/asciidoc/Objectives.adoc
@@ -4,89 +4,81 @@ This section lists the high level objectives of this specification.
 
 * Build on the evolving industry standards for Web services,
 specifically WSDL 1.1, SOAP 1.1 and SOAP 1.2.
-* Leverage existing Java EE technology.
+* Leverage existing Jakarta EE technology.
 * Ensure that programmers may implement and package Web services that
-properly deploy onto application servers that comply with Java EE and
+properly deploy onto application servers that comply with Jakarta EE and
 this specification.
 * Ensure that vendor implementations of this specification
 inter-operate, i.e. a Web service client on one vendor’s implementation
 must be able to interact with Web services executing on another vendors
 implementation.
 * Define the minimal set of new concepts, interfaces, file formats, etc.
-necessary to support Web services within Java EE.
-* Clearly and succinctly define functions that Java EE application
+necessary to support Web services within Jakarta EE.
+* Clearly and succinctly define functions that Jakarta EE application
 server vendors need to provide.
 * Define the roles that this specification requires, the functions they
-perform and their mapping to Java EE platform roles. Define the
-functions that a Web Services for Java EE product provider must provide
+perform and their mapping to Jakarta EE platform roles. Define the
+functions that a Web Services for Jakarta EE product provider must provide
 to support these roles.
 * Support a simple model for defining a new Web service and deploying
-this into a Java EE application server.
+this into a Jakarta EE application server.
 
 === Client Model Goals
 
 The client programming model should be conformant and compatible with
-the client programming model defined by JAX-RPC or JAX-WS.
+the client programming model defined by JAX-WS.
 
 Additional goals for the client programming model are to ensure that:
 
 * Programmers can implement Web services client applications conforming
-to this specification that may reside in a Java EE container (e.g. an
-EJB that uses a Web service), or a Java EE Client Container can call a
-Web service running in a Web Services for Java EE container.
+to this specification that may reside in a Jakarta EE container (e.g. an
+EJB that uses a Web service), or a Jakarta EE Client Container can call a
+Web service running in a Web Services for Jakarta EE container.
 * Client applications conforming to this specification can call any SOAP
 1.1 or SOAP 1.2 based Web service through the HTTP 1.1 or HTTPS SOAP
 Bindings.
-* Programmers using other client environments such as Java 2 Standard
-Edition environment can call a Web service running in a Web Services for
-Java EE container. Programmers using languages other than Java must be
-able to implement SOAP 1.1 or SOAP 1.2 compliant applications that can
-use Web services conforming to this specification. Support the Client
-Development Scenarios described in Chapter 4.
+* Programmers using other client environments can call a Web service
+running in a Web Services for Jakarta EE container. Programmers using
+languages other than Java must be able to implement SOAP 1.1 or SOAP 1.2
+compliant applications that can use Web services conforming to this
+specification. Support the Client Development Scenarios described in
+Chapter 4.
 * Client developers must not have to be aware of how the service
 implementation is realized.
-* Java 2 Micro Edition clients, defined by JSR 172, should be able to
-interoperate using the transport standards declared within WSDL and the
-JAX-RPC or JAX-WS runtime with Web Services for Java EE applications.
 
 === Service Development Goals
 
 The service development model defines how web service implementations
-are to be developed and deployed into existing Java EE containers and
+are to be developed and deployed into existing Jakarta EE containers and
 includes the following specific goals:
 
 * How the Web service has been implemented should be transparent to the
 Web service client. A client should not have to know if the Web service
-has been deployed in a Java EE or non-Java EE environment.
-* Because the Web service implementation must be deployed in a Java EE
+has been deployed in a Jakarta EE or non-Jakarta EE environment.
+* Because the Web service implementation must be deployed in a Jakarta EE
 container, the class implementing the service must conform to some
 defined requirements to ensure that it does not compromise the integrity
 of the application server.
-* JAX-RPC defines three server side run time categories, J2SE based
-JAX-RPC Runtime, Servlet Container Based JAX-RPC Runtime, and Java EE
-Container Based JAX-RPC Runtime. This specification defines the Java EE
-container based (Web and EJB) runtime such that it is consistent with
-the Servlet Container based model defined by the JAX-RPC specification.
-* This specification is amended to define the Java EE container based
-(Web and EJB) runtime such that it is consistent with the programming
-model defined by the JAX-WS specification.
+* This specification defines the Jakarta EE container based (Web and EJB)
+runtime such that it is consistent with the programming model defined by
+the JAX-WS specification.
 * Support mapping and dispatching SOAP 1.1 or 1.2 requests to methods on
-Java EE Stateless or Singleton(only JAX-WS) Session Beans.
+Jakarta EE Stateless or Singleton(only JAX-WS) Session Beans.
 * Support mapping and dispatching SOAP 1.1 or 1.2 requests to methods on
-JAX-RPC or JAX-WS Service Endpoint classes in the Web Container.
+JAX-WS Service Endpoint classes in the Web Container.
 
 === Service Deployment Goals
 
 * Web service deployment is declarative. We do this through extending
-the Java EE model for deployment descriptors and EAR file format. These
+the Jakarta EE model for deployment descriptors and EAR file format. These
 changes are minimized, however.
-* Web service deployment is supported on Java EE environments.
+* Web service deployment is supported on Jakarta EE environments.
 * Deployment requires that a service be representable by WSDL.
 Deployment requires a WSDL file. The deployment of Web services must
 support:
 
 * those who wish to deploy a Web service as the focus of the deployment
-* those who wish to expose existing, deployed Java EE components as a
+* those who wish to expose existing, deployed Jakarta EE components as a
 Web service
 
 === Service Publication Goals

--- a/enterprise-ws-spec/src/main/asciidoc/Objectives.adoc
+++ b/enterprise-ws-spec/src/main/asciidoc/Objectives.adoc
@@ -42,7 +42,7 @@ running in a Web Services for Jakarta EE container. Programmers using
 languages other than Java must be able to implement SOAP 1.1 or SOAP 1.2
 compliant applications that can use Web services conforming to this
 specification. Support the Client Development Scenarios described in
-Chapter 4.
+<<ClientProgrammingModel.adoc#anchor-13, Chapter 4>>.
 * Client developers must not have to be aware of how the service
 implementation is realized.
 
@@ -77,8 +77,8 @@ changes are minimized, however.
 Deployment requires a WSDL file. The deployment of Web services must
 support:
 
-* those who wish to deploy a Web service as the focus of the deployment
-* those who wish to expose existing, deployed Jakarta EE components as a
+** those who wish to deploy a Web service as the focus of the deployment
+** those who wish to expose existing, deployed Jakarta EE components as a
 Web service
 
 === Service Publication Goals
@@ -91,20 +91,3 @@ deployment package or during the deployment process.
 * If any publication to UDDI is performed, the WSDL must also be made
 available at a URL.
 
-=== Web Services Registry Goals
-
-The Web services registry API and programming model is out of the scope
-of this specification. The Web service implementation, Web service
-client, or Web service deployment tool may use any registry API
-including JAX-R. JAX-R does not support WSDL publication directly. It
-does support interaction with UDDI directories. UDDI.org specifies how
-to publish a WSDL described service to a UDDI directory.
-
-This specification defines the service publication responsibilities of
-the deployment tool.
-
-Service definition discovery (finding the WSDL to be implemented) during
-development or deployment of a service implementation is not defined.
-
-Service discovery during development, deployment, or runtime of service
-clients is not defined.

--- a/enterprise-ws-spec/src/main/asciidoc/Overview.adoc
+++ b/enterprise-ws-spec/src/main/asciidoc/Overview.adoc
@@ -40,7 +40,7 @@ with the following characteristics:
 
 * A service implementation implements the methods of an interface that
 is describable by WSDL. The methods are implemented using a
-Stateless/Singleton Session EJB or JAX-WS web component.
+Stateless/Singleton Session EJB or Jakarta XML Web Services web component.
 * A Web service may have its interface published in one or more
 registries for Web services during deployment.
 * A Web Service implementation, which uses only the functionality
@@ -53,13 +53,13 @@ separate from the service implementation. Tools can define these
 requirements during assembly or deployment.
 * A container mediates access to the service.
 
-JAX-WS defines a programming model mapping of a WSDL document
+Jakarta XML Web Services defines a programming model mapping of a WSDL document
 to Java which provides a factory (Service) for selecting which
 aggregated Port a client wishes to use. See link:#anchor-5[Figure 2] for
 a logical diagram. In general, the transport, encoding, and address of
 the Port are transparent to the client. The client only needs to make
 method calls on the Service Endpoint Interface, as defined by
-JAX-WS, (i.e. PortType) to access the service. See Chapter
+Jakarta XML Web Services, (i.e. PortType) to access the service. See Chapter
 link:#anchor-6[4] for more details.
 
 image:2.png[image,width=277,height=135]
@@ -87,8 +87,8 @@ client, web, and EJB containers. This specification does not require
 that a Port be accessible from the applet container.
 
 This specification adds additional artifacts to those defined by
-JAX-WS that may be used to implement Web services, a role based
-development methodology, portable packaging and Jakarta EE container
+Jakarta XML Web Services that may be used to implement Web services, a role
+based development methodology, portable packaging and Jakarta EE container
 services to the Web services architecture. These are described in later
 sections.
 
@@ -97,11 +97,11 @@ sections.
 This specification defines two means for implementing a Web service,
 which runs in a Jakarta EE environment, but does not restrict Web service
 implementations to just those means. The first is a container based
-extension of the JAX-WS programming model which defines a Web
+extension of the Jakarta XML Web Services programming model which defines a Web
 service as a Java class running in the web container. The second uses a
 constrained implementation of a stateless session EJB or singleton
-session EJB(only for JAX-WS services) in the EJB container. Other
-service implementations are possible, but are not defined by this
+session EJB(only for Jakarta XML Web Services services) in the EJB container.
+Other service implementations are possible, but are not defined by this
 specification.
 
 ==== Web Service Containers
@@ -114,7 +114,7 @@ does not require that a new container be implemented. Existing Jakarta EE
 containers may be used and indeed are expected to be used to host Web
 services. Web service instance life cycle and concurrency management is
 dependent on which container the service implementation runs in. A
-JAX-WS Service Endpoint implementation in a web container
+Jakarta XML Web Services Service Endpoint implementation in a web container
 follows standard servlet life cycle and concurrency requirements and an
 EJB implementation in an EJB container follows standard EJB life cycle
 and concurrency requirements.
@@ -158,7 +158,12 @@ The Jakarta EE platform defines a set of standard services a Jakarta EE
 provider must supply. The Web Services for Jakarta EE specification
 identifies an additional set of run-time services that are required.
 
-==== JAX-WS 3.0
+==== Jakarta XML Web Services
+
+Jakarta XML Web Services is based on the JAX-WS specification from the
+Java EE specification. This document refers to version 3.0 of the 
+Jakarta XML Web Services specification and APIs unless explicitly 
+noted otherwise.
 
 JAX-WS 2.0 is a follow-on specification to JAX-RPC 1.1. In addition to
 providing all the run-time services, it improves upon JAX-RPC 1.1
@@ -170,9 +175,9 @@ JAX-WS 2.2 adds a complete Web Services addressing support as specified
 in Web Services Addressing 1.0 - Core, Web Services Addressing 1.0 -
 Soap Binding, and Web Services Addressing 1.0 - Metadata.
 
-JAX-WS 3.0 renames the JAX-WS API packages from `javax.*` to `jakarta.*`. 
-Beginning in Java™ 11, the JAX-WS APIs are no longer available as part
-of the Java SE class library.
+Jakarta XML Web Services 3.0 renames the JAX-WS API packages from `javax.*`
+to `jakarta.*`. Beginning in Java SE 11, the JAX-WS APIs are no longer
+available as part of the Java SE class library.
 
 === Interoperability
 
@@ -185,7 +190,7 @@ this specification depends on.
 The specification builds on the evolving work of the following JSRs and
 specifications:
 
-* Jakarta API for XML-based Web Services (JAX-WS) 3.0
+* Jakarta API for XML-based Web Services
 * Jakarta Enterprise Edition Specification
 * Jakarta Enterprise Beans Specification
 * Jakarta Servlet Specification
@@ -246,7 +251,7 @@ Web service. This includes the following:
 * Service interface or class
 * Service Endpoint interface
 
-The JAX-WS Handler interface is considered a container SPI
+The Jakarta XML Web Services Handler interface is considered a container SPI
 and is therefore not part of the client view.
 
 image:4.png[image,width=282,height=139]
@@ -256,11 +261,11 @@ Figure 4 Web Service Client View
 The Service Interface/Class defines the methods a client may use to
 access a Port of a Web service. A client does not create or remove a
 Port. It uses the Service Interface/Class to obtain access to a Port.
-The Service interface/class is defined by the JAX-WS specification, but 
-its behavior is defined by a WSDL document supplied
+The Service interface/class is defined by the Jakarta XML Web Services
+specification, but its behavior is defined by a WSDL document supplied
 by the Web service provider. The container’s deployment tools provide an
 implementation of the methods of the Service Interface/Class or the
-JAX-WS Generated Service Interface.
+Jakarta XML Web Services Generated Service Interface.
 
 A client locates a Service Interface by using JNDI APIs. This is
 explained further in Chapter link:#anchor-8[4].
@@ -283,8 +288,8 @@ defines the general requirements for the service provider.
 
 The service provider defines the WSDL PortType, WSDL binding, and
 Service Endpoint Interface of a Web service. The PortType and Service
-Endpoint Interface must follow the JAX-WS rules for WSDL->Java and 
-Java->WSDL mapping.
+Endpoint Interface must follow the Jakarta XML Web Services rules for
+WSDL->Java and Java->WSDL mapping.
 
 The service provider defines the WSDL service and aggregation of ports
 in the WSDL document.
@@ -298,20 +303,20 @@ service business logic by creating a stateless session Bean that
 implements the methods of the Service Endpoint Interface as described in
 the Jakarta Enterprise Beans 4.0 specification.
 . A Java class: The service provider implements the Web service business
-logic according to the requirements defined by the JAX-WS
+logic according to the requirements defined by the Jakarta XML Web Services
 Servlet based service implementation model.
-. A Singleton Session Bean: The service provider implements the JAX-WS
-Web service business logic by creating a singleton session bean that
-implements the methods of the Service Endpoint Interface as described in
+. A Singleton Session Bean: The service provider implements the Jakarta XML
+Web Services Web service business logic by creating a singleton session bean
+that implements the methods of the Service Endpoint Interface as described in
 the Jakarta Enterprise Bean 4.0 specification.
 
 The life cycle management of a Web service is specific to the service
 implementation methodology.
 
 The service provider implements the container callback methods specific
-to the service implementation methodology used. See the JAX-WS
-specification and Jakarta Enterprise Beans specification for details on the
-container callback methods.
+to the service implementation methodology used. See the Jakarta XML Web
+Services specification and Jakarta Enterprise Beans specification for details
+on the container callback methods.
 
 The container manages the run-time services required by the Web service,
 such as security. The default behavior requires that if a client
@@ -339,12 +344,12 @@ The Jakarta EE platform specification defines "profiles" to target
 specific class of applications.
 
 The Jakarta EE 9 platform removes JAX-RPC from all profiles, and it
-includes JAX-WS in the full profile.
+includes Jakarta XML Web Services in the full profile.
 
 This specification gives choices for the vendors that want to support
-only certain containers for JAX-WS web services. An Enterprise Web Service
-implementation must support at least one of the following configurations
-for JAX-WS web services:
+only certain containers for Jakarta XML Web Services web services. An
+Enterprise Web Service implementation must support at least one of the
+following configurations for Jakarta XML Web Services web services:
 
-* JAX-WS web component in a Servlet container
-* Stateless or Singleton Session EJB as JAX-WS web service
+* Jakarta XML Web Services web component in a Servlet container
+* Stateless or Singleton Session EJB as Jakarta XML Web Services web service

--- a/enterprise-ws-spec/src/main/asciidoc/Overview.adoc
+++ b/enterprise-ws-spec/src/main/asciidoc/Overview.adoc
@@ -1,7 +1,7 @@
 == Overview
 
 This chapter provides an overview of Web services in general and how Web
-Services for Java EE fits into the Java EE platform.
+Services for Jakarta EE fits into the Jakarta EE platform.
 
 === Web Services Architecture Overview
 
@@ -40,12 +40,12 @@ with the following characteristics:
 
 * A service implementation implements the methods of an interface that
 is describable by WSDL. The methods are implemented using a
-Stateless/Singleton Session EJB or JAX-RPC/JAX-WS web component.
+Stateless/Singleton Session EJB or JAX-WS web component.
 * A Web service may have its interface published in one or more
 registries for Web services during deployment.
 * A Web Service implementation, which uses only the functionality
 described by this specification, can be deployed in any Web Services for
-Java EE compliant application server.
+Jakarta EE compliant application server.
 * A service instance, called a Port, is created and managed by a
 container.
 * Run-time service requirements, such as security attributes, are
@@ -53,12 +53,12 @@ separate from the service implementation. Tools can define these
 requirements during assembly or deployment.
 * A container mediates access to the service.
 
-JAX-RPC and JAX-WS define a programming model mapping of a WSDL document
+JAX-WS defines a programming model mapping of a WSDL document
 to Java which provides a factory (Service) for selecting which
 aggregated Port a client wishes to use. See link:#anchor-5[Figure 2] for
 a logical diagram. In general, the transport, encoding, and address of
 the Port are transparent to the client. The client only needs to make
-method calls on the Service Endpoint Interface, as defined by JAX-RPC or
+method calls on the Service Endpoint Interface, as defined by
 JAX-WS, (i.e. PortType) to access the service. See Chapter
 link:#anchor-6[4] for more details.
 
@@ -66,36 +66,38 @@ image:2.png[image,width=277,height=135]
 
 * [#anchor-5]##Figure 2 Client view
 
-=== Web Services for _*Java EE*_ Overview
+=== Web Services for _*Jakarta EE*_ Overview
 
-The Web Services for Java EE specification defines the required
+The Web Services for Jakarta EE specification defines the required
 architectural relationships as shown in link:#anchor-7[Figure 3]. This
 is a logical relationship and does not impose any requirements on a
 container provider for structuring containers and processes. The
-additions to the Java EE platform include a port component that depends
+additions to the Jakarta EE platform include a port component that depends
 on container functionality provided by the web and EJB containers, and
 the SOAP/HTTP transport.
 
+//TODO: image 3.png mentions J2EE - should be replaced with Jakarta EE?
+
 image:3.png[image,width=371,height=280]
 
-* [#anchor-7]##Figure 3 Java EE architecture diagram
+* [#anchor-7]##Figure 3 Jakarta EE architecture diagram
 
-Web Services for Java EE requires that a Port be referencable from the
+Web Services for Jakarta EE requires that a Port be referencable from the
 client, web, and EJB containers. This specification does not require
 that a Port be accessible from the applet container.
 
-This specification adds additional artifacts to those defined by JAX-RPC
-or JAX-WS that may be used to implement Web services, a role based
-development methodology, portable packaging and Java EE container
+This specification adds additional artifacts to those defined by
+JAX-WS that may be used to implement Web services, a role based
+development methodology, portable packaging and Jakarta EE container
 services to the Web services architecture. These are described in later
 sections.
 
 ==== Web Service Components
 
 This specification defines two means for implementing a Web service,
-which runs in a Java EE environment, but does not restrict Web service
+which runs in a Jakarta EE environment, but does not restrict Web service
 implementations to just those means. The first is a container based
-extension of the JAX-RPC or JAX-WS programming model which defines a Web
+extension of the JAX-WS programming model which defines a Web
 service as a Java class running in the web container. The second uses a
 constrained implementation of a stateless session EJB or singleton
 session EJB(only for JAX-WS services) in the EJB container. Other
@@ -107,29 +109,29 @@ specification.
 The container provides for life cycle management of the service
 implementation, concurrency management of method invocations, and
 security services. A container provides the services specific to
-supporting Web services in a Java EE environment. This specification
-does not require that a new container be implemented. Existing Java EE
+supporting Web services in a Jakarta EE environment. This specification
+does not require that a new container be implemented. Existing Jakarta EE
 containers may be used and indeed are expected to be used to host Web
 services. Web service instance life cycle and concurrency management is
 dependent on which container the service implementation runs in. A
-JAX-RPC or JAX-WS Service Endpoint implementation in a web container
+JAX-WS Service Endpoint implementation in a web container
 follows standard servlet life cycle and concurrency requirements and an
 EJB implementation in an EJB container follows standard EJB life cycle
 and concurrency requirements.
 
 === Platform Roles
 
-This specification defines the responsibilities of the existing Java EE
-platform roles. There are no new roles defined by this specification.
-There are two roles specific to Web Services for Java EE used within
-this specification, but they can be mapped onto existing Java EE
-platform roles. The Web Services for Java EE product provider role can
-be mapped to a Java EE product provider role and the Web services
+This specification defines the responsibilities of the existing Jakarta 
+EE platform roles. There are no new roles defined by this specification.
+There are two roles specific to Web Services for Jakarta EE used within
+this specification, but they can be mapped onto existing Jakarta EE
+platform roles. The Web Services for Jakarta EE product provider role can
+be mapped to a Jakarta EE product provider role and the Web services
 container provider role can be mapped to a container provider role
-within the Java EE specification.
+within the Jakarta EE specification.
 
 In general, the developer role is responsible for the service
-definition, implementation, and packaging within a Java EE module. The
+definition, implementation, and packaging within a Jakarta EE module. The
 assembler role is responsible for assembling the module into an
 application, and the deployer role is responsible for publishing the
 deployed services and resolving client references to services. More
@@ -140,9 +142,9 @@ details on role responsibilities can be found in later sections.
 A standard packaging format, declarative deployment model, and standard
 run-time services provide portability of applications developed using
 Web services. A Web services specific deployment descriptor included in
-a standard Java EE module defines the Web service use of that module.
+a standard Jakarta EE module defines the Web service use of that module.
 More details on Web services deployment descriptors can be found in
-later chapters. Deployment tools supporting Web Services for Java EE are
+later chapters. Deployment tools supporting Web Services for Jakarta EE are
 required to be able to deploy applications packaged according to this
 specification.
 
@@ -152,18 +154,11 @@ at the possible expense of application portability.
 
 === Standard Services
 
-The Java EE platform defines a set of standard services a Java EE
-provider must supply. The Web Services for Java EE specification
+The Jakarta EE platform defines a set of standard services a Jakarta EE
+provider must supply. The Web Services for Jakarta EE specification
 identifies an additional set of run-time services that are required.
 
-==== JAX-RPC1.1
-
-JAX-RPC 1.1 provides run-time services for marshalling and demarshalling
-Java data and objects to and from XML SOAP messages. In addition,
-JAX-RPC defines the WSDL to Java mappings for a Service Endpoint
-Interface and a Service class.
-
-==== JAX-WS 2.2
+==== JAX-WS 3.0
 
 JAX-WS 2.0 is a follow-on specification to JAX-RPC 1.1. In addition to
 providing all the run-time services, it improves upon JAX-RPC 1.1
@@ -175,22 +170,25 @@ JAX-WS 2.2 adds a complete Web Services addressing support as specified
 in Web Services Addressing 1.0 - Core, Web Services Addressing 1.0 -
 Soap Binding, and Web Services Addressing 1.0 - Metadata.
 
+JAX-WS 3.0 renames the JAX-WS API packages from `javax.*` to `jakarta.*`. 
+Beginning in Java™ 11, the JAX-WS APIs are no longer available as part
+of the Java SE class library.
+
 === Interoperability
 
-This specification extends the interoperability requirements of the Java
+This specification extends the interoperability requirements of the Jakarta
 EE platform by defining interoperability requirements for products that
-implement this specification on top of Java EE™. The interoperability
+implement this specification on top of Jakarta EE. The interoperability
 requirements rely on the interoperability of existing standards that
 this specification depends on.
 
 The specification builds on the evolving work of the following JSRs and
 specifications:
 
-* Java™ API for XML-based RPC (JAX-RPC) 1.1
-* Java™ API for XML-based Web Services (JAX-WS) 2.2
-* Java Enterprise Edition Specification
-* Enterprise JavaBeans Specification
-* Java Servlet Specification
+* Jakarta API for XML-based Web Services (JAX-WS) 3.0
+* Jakarta Enterprise Edition Specification
+* Jakarta Enterprise Beans Specification
+* Jakarta Servlet Specification
 * WS-I Basic Profile 1.0
 
 === Scope
@@ -218,8 +216,8 @@ SOAP, WSDL, and UDDI are assumed to be the versions defined above.
 ==== Not in Scope
 
 * The most glaring deficiency of SOAP over HTTP is basic reliable
-message semantics. Despite this deficiency, this JSR does not consider
-Message Reliability or Message Integrity to be in scope. Other JSRs,
+message semantics. Despite this deficiency, this specification does not
+consider Message Reliability or Message Integrity to be in scope. Other JSRs,
 like the evolution and convergence of JAX-M and JMS, as well as
 activities in W3C and other standard bodies will define these
 capabilities.
@@ -232,10 +230,10 @@ to this specification.
 === Web Service Client View
 
 The client view of a Web service is quite similar to the client view of
-an Enterprise JavaBean. A client of a Web service can be another Web
-service, a Java EE component, including a Java EE application client, or
+a Jakarta Enterprise Bean. A client of a Web service can be another Web
+service, a Jakarta EE component, including a Jakarta EE application client, or
 an arbitrary Java application. A non-Java application or non-Web
-Services for Java EE application can also be a client of Web service,
+Services for Jakarta EE application can also be a client of Web service,
 but the client view for such applications is out of scope of this
 specification.
 
@@ -248,7 +246,7 @@ Web service. This includes the following:
 * Service interface or class
 * Service Endpoint interface
 
-The JAX-RPC or JAX-WS Handler interface is considered a container SPI
+The JAX-WS Handler interface is considered a container SPI
 and is therefore not part of the client view.
 
 image:4.png[image,width=282,height=139]
@@ -258,11 +256,11 @@ Figure 4 Web Service Client View
 The Service Interface/Class defines the methods a client may use to
 access a Port of a Web service. A client does not create or remove a
 Port. It uses the Service Interface/Class to obtain access to a Port.
-The Service interface/class is defined by the JAX-RPC or JAX-WS
-specification, but its behavior is defined by a WSDL document supplied
+The Service interface/class is defined by the JAX-WS specification, but 
+its behavior is defined by a WSDL document supplied
 by the Web service provider. The container’s deployment tools provide an
 implementation of the methods of the Service Interface/Class or the
-JAX-RPC or JAX-WS Generated Service Interface.
+JAX-WS Generated Service Interface.
 
 A client locates a Service Interface by using JNDI APIs. This is
 explained further in Chapter link:#anchor-8[4].
@@ -272,10 +270,7 @@ Endpoint Interface. The Service Endpoint Interface is specified by the
 service provider. The deployment tools and container run-time provide
 server side classes which dispatch a SOAP request to a Web service
 implementation which implements the methods of the Service Endpoint
-Interface. The Service Endpoint Interface extends the java.rmi.Remote
-interface and is fully defined by the JAX-RPC specification. JAX-WS
-specification does not require Service Endpoint Interface to extend the
-java.rmi.Remote interface
+Interface.
 
 A Port has no identity within the client view and is considered a
 stateless object.
@@ -288,8 +283,8 @@ defines the general requirements for the service provider.
 
 The service provider defines the WSDL PortType, WSDL binding, and
 Service Endpoint Interface of a Web service. The PortType and Service
-Endpoint Interface must follow the JAX-RPC or JAX-WS rules for
-WSDL->Java and Java->WSDL mapping.
+Endpoint Interface must follow the JAX-WS rules for WSDL->Java and 
+Java->WSDL mapping.
 
 The service provider defines the WSDL service and aggregation of ports
 in the WSDL document.
@@ -301,21 +296,21 @@ in one of two different ways:
 . A Stateless Session Bean: The service provider implements the Web
 service business logic by creating a stateless session Bean that
 implements the methods of the Service Endpoint Interface as described in
-the Enterprise JavaBeans 3.0 specification.
+the Jakarta Enterprise Beans 4.0 specification.
 . A Java class: The service provider implements the Web service business
-logic according to the requirements defined by the JAX-RPC or JAX-WS
+logic according to the requirements defined by the JAX-WS
 Servlet based service implementation model.
 . A Singleton Session Bean: The service provider implements the JAX-WS
 Web service business logic by creating a singleton session bean that
 implements the methods of the Service Endpoint Interface as described in
-the EJB 3.1 specification.
+the Jakarta Enterprise Bean 4.0 specification.
 
 The life cycle management of a Web service is specific to the service
 implementation methodology.
 
 The service provider implements the container callback methods specific
-to the service implementation methodology used. See the JAX-RPC, JAX-WS
-specification and Enterprise JavaBeans specification for details on the
+to the service implementation methodology used. See the JAX-WS
+specification and Jakarta Enterprise Beans specification for details on the
 container callback methods.
 
 The container manages the run-time services required by the Web service,
@@ -327,31 +322,27 @@ transaction propagation (e.g. using WS-AtomicTransaction) as long as the
 transactional behavior is consistent for local and remote invocations.
 
 Service providers must avoid programming practices that interfere with
-container operation. These restrictions are defined by the Java EE,
+container operation. These restrictions are defined by the Jakarta EE,
 Servlet, and EJB specifications.
 
-Packaging of a Web service in a Java EE module is specific to the
-service implementation methodology, but follows the Java EE requirements
-for an EJB-JAR file or WAR file. It contains the Java class files of the
+Packaging of a Web service in a Jakarta EE module is specific to the
+service implementation methodology, but follows the Jakarta EE requirements
+for an EJB-JAR file or WAR file. It contains the Jakarta class files of the
 Service Endpoint Interface and WSDL documents for the Web service. In
 addition it contains an XML deployment descriptor which defines the Web
 service Ports and their structure. Packaging requirements are described
 in Section link:#anchor-11[5.4] link:#anchor-12[Packaging].
 
-=== Java EE profiles
+=== Jakarta EE profiles
 
-The Java EE 6 platform specification introduces "profiles" to target
-specific class of applications. See chapter 9 of Java EE 6 specification
-for more details.
+The Jakarta EE platform specification defines "profiles" to target
+specific class of applications.
 
-The Java EE 6 platform marks JAX-RPC as a proposed optional technology
-that may be pruned in a future release. Therefore, requirements in this
-specification related to JAX-RPC should also be considered proposed
-optional. Such requirements may be made optional in a future release of
-this specification.
+The Jakarta EE 9 platform removes JAX-RPC from all profiles, and it
+includes JAX-WS in the full profile.
 
 This specification gives choices for the vendors that want to support
-only certain containers for JAX-WS web services. A JSR-109
+only certain containers for JAX-WS web services. An Enterprise Web Service
 implementation must support at least one of the following configurations
 for JAX-WS web services:
 

--- a/enterprise-ws-spec/src/main/asciidoc/Overview.adoc
+++ b/enterprise-ws-spec/src/main/asciidoc/Overview.adoc
@@ -55,21 +55,23 @@ requirements during assembly or deployment.
 
 Jakarta XML Web Services defines a programming model mapping of a WSDL document
 to Java which provides a factory (Service) for selecting which
-aggregated Port a client wishes to use. See link:#anchor-5[Figure 2] for
+aggregated Port a client wishes to use. See <<figure2,Figure 2>> for
 a logical diagram. In general, the transport, encoding, and address of
 the Port are transparent to the client. The client only needs to make
 method calls on the Service Endpoint Interface, as defined by
-Jakarta XML Web Services, (i.e. PortType) to access the service. See Chapter
-link:#anchor-6[4] for more details.
+Jakarta XML Web Services, (i.e. PortType) to access the service. See
+<<ClientProgrammingModel.adoc#anchor-13, Chapter 4>> for more details.
 
+
+[#figure2]
 image:2.png[image,width=277,height=135]
 
-* [#anchor-5]##Figure 2 Client view
+* Figure 2 Client view
 
-=== Web Services for _*Jakarta EE*_ Overview
+=== Web Services for Jakarta EE Overview
 
 The Web Services for Jakarta EE specification defines the required
-architectural relationships as shown in link:#anchor-7[Figure 3]. This
+architectural relationships as shown in <<figure3,Figure 3>>. This
 is a logical relationship and does not impose any requirements on a
 container provider for structuring containers and processes. The
 additions to the Jakarta EE platform include a port component that depends
@@ -77,10 +79,10 @@ on container functionality provided by the web and EJB containers, and
 the SOAP/HTTP transport.
 
 //TODO: image 3.png mentions J2EE - should be replaced with Jakarta EE?
-
+[#figure3]
 image:3.png[image,width=371,height=280]
 
-* [#anchor-7]##Figure 3 Jakarta EE architecture diagram
+* Figure 3 Jakarta EE architecture diagram
 
 Web Services for Jakarta EE requires that a Port be referencable from the
 client, web, and EJB containers. This specification does not require
@@ -100,7 +102,7 @@ implementations to just those means. The first is a container based
 extension of the Jakarta XML Web Services programming model which defines a Web
 service as a Java class running in the web container. The second uses a
 constrained implementation of a stateless session EJB or singleton
-session EJB(only for Jakarta XML Web Services services) in the EJB container.
+session EJB in the EJB container.
 Other service implementations are possible, but are not defined by this
 specification.
 
@@ -175,9 +177,9 @@ JAX-WS 2.2 adds a complete Web Services addressing support as specified
 in Web Services Addressing 1.0 - Core, Web Services Addressing 1.0 -
 Soap Binding, and Web Services Addressing 1.0 - Metadata.
 
-Jakarta XML Web Services 3.0 renames the JAX-WS API packages from `javax.*`
-to `jakarta.*`. Beginning in Java SE 11, the JAX-WS APIs are no longer
-available as part of the Java SE class library.
+Jakarta XML Web Services 3.0 is a next version of renames the JAX-WS 2.2
+specification. It mvoes existing APIs from javax.xml.ws packages to
+jakarta.xml.ws packages.
 
 === Interoperability
 
@@ -190,7 +192,8 @@ this specification depends on.
 The specification builds on the evolving work of the following JSRs and
 specifications:
 
-* Jakarta API for XML-based Web Services
+* Jakarta XML-RPC
+* Jakarta XML Web Services
 * Jakarta Enterprise Edition Specification
 * Jakarta Enterprise Beans Specification
 * Jakarta Servlet Specification
@@ -268,7 +271,7 @@ implementation of the methods of the Service Interface/Class or the
 Jakarta XML Web Services Generated Service Interface.
 
 A client locates a Service Interface by using JNDI APIs. This is
-explained further in Chapter link:#anchor-8[4].
+explained further in <<ClientProgrammingModel.adoc#anchor-13, Chapter 4>>.
 
 A Web service implementation is accessed by the client using the Service
 Endpoint Interface. The Service Endpoint Interface is specified by the
@@ -282,7 +285,7 @@ stateless object.
 
 ===  Web Service Server View
 
-Chapter link:#anchor-9[5] link:#anchor-10[Server Programming Model]
+<<ServerProgrammingModel.adoc#anchor-10, Chapter 5>>
 defines the details of the server programming model. This section
 defines the general requirements for the service provider.
 
@@ -301,14 +304,14 @@ in one of two different ways:
 . A Stateless Session Bean: The service provider implements the Web
 service business logic by creating a stateless session Bean that
 implements the methods of the Service Endpoint Interface as described in
-the Jakarta Enterprise Beans 4.0 specification.
+the Jakarta Enterprise Beans specification.
 . A Java class: The service provider implements the Web service business
 logic according to the requirements defined by the Jakarta XML Web Services
 Servlet based service implementation model.
 . A Singleton Session Bean: The service provider implements the Jakarta XML
 Web Services Web service business logic by creating a singleton session bean
 that implements the methods of the Service Endpoint Interface as described in
-the Jakarta Enterprise Bean 4.0 specification.
+the Jakarta Enterprise Bean specification.
 
 The life cycle management of a Web service is specific to the service
 implementation methodology.
@@ -336,14 +339,14 @@ for an EJB-JAR file or WAR file. It contains the Jakarta class files of the
 Service Endpoint Interface and WSDL documents for the Web service. In
 addition it contains an XML deployment descriptor which defines the Web
 service Ports and their structure. Packaging requirements are described
-in Section link:#anchor-11[5.4] link:#anchor-12[Packaging].
+in <<ServerProgrammingModel.adoc#anchor-51, Section 5.4>>.
 
 === Jakarta EE profiles
 
 The Jakarta EE platform specification defines "profiles" to target
 specific class of applications.
 
-The Jakarta EE 9 platform removes JAX-RPC from all profiles, and it
+The Jakarta EE 9 platform removes Jakarta XML-RPC from all profiles, and it
 includes Jakarta XML Web Services in the full profile.
 
 This specification gives choices for the vendors that want to support

--- a/enterprise-ws-spec/src/main/asciidoc/Overview.adoc
+++ b/enterprise-ws-spec/src/main/asciidoc/Overview.adoc
@@ -177,8 +177,8 @@ JAX-WS 2.2 adds a complete Web Services addressing support as specified
 in Web Services Addressing 1.0 - Core, Web Services Addressing 1.0 -
 Soap Binding, and Web Services Addressing 1.0 - Metadata.
 
-Jakarta XML Web Services 3.0 is a next version of renames the JAX-WS 2.2
-specification. It mvoes existing APIs from javax.xml.ws packages to
+Jakarta XML Web Services 3.0 is a next version of the JAX-WS 2.2
+specification. It moves existing APIs from javax.xml.ws packages to
 jakarta.xml.ws packages.
 
 === Interoperability
@@ -209,9 +209,9 @@ covered by this specification.
 * The scope of this specification is limited to Web service standards
 that are widely documented and accepted in the industry. These include:
 
-* SOAP 1.1, SOAP 1.2 and SOAP with Attachments
-* WSDL 1.1
-* UDDI 1.0
+** SOAP 1.1, SOAP 1.2 and SOAP with Attachments
+** WSDL 1.1
+** UDDI 1.0
 
 * This specification is limited to defining support for SOAP over HTTP
 1.1 or HTTPS protocols and communication APIs for Web services (vendors


### PR DESCRIPTION
In general, this PR should:
- Java EE -> Jakarta EE
- Removing references to JAX-RPC
- Enterprise JavaBeans -> Jakarta Enterprise Beans
- Version updates where applicable

This PR is still in progress.  Feedback welcome at any point (so far, only 3 chapters done).

Completes chapters 1-4 of #118.