### PR TITLE
remove java se specifics from the spec, the API is no longer part of Java SE

### DIFF
--- a/spec/src/main/asciidoc/appB-change_log.adoc
+++ b/spec/src/main/asciidoc/appB-change_log.adoc
@@ -12,6 +12,7 @@
 * Package namespace changed to `jakarta.xml.ws.*`.
 * Alignment with Jakarta XML Binding 3.0
 * Drop requirements related to JAX-WS inclusion in Java SE
+* Updated namespace of customization schema to `https://jakarta.ee/xml/ns/jaxws` and bumped schema version to `3.0`
 
 [[changes]]
 === 2.3 Changes

--- a/spec/src/main/asciidoc/appB-change_log.adoc
+++ b/spec/src/main/asciidoc/appB-change_log.adoc
@@ -11,6 +11,7 @@
 * Changed specification version and license.
 * Package namespace changed to `jakarta.xml.ws.*`.
 * Alignment with Jakarta XML Binding 3.0
+* Drop requirements related to JAX-WS inclusion in Java SE
 
 [[changes]]
 === 2.3 Changes

--- a/spec/src/main/asciidoc/ch01-introduction.adoc
+++ b/spec/src/main/asciidoc/ch01-introduction.adoc
@@ -404,7 +404,7 @@ schema<<bib5>>
 SOAP binding schema<<bib24>><<bib25>>
 |jaxb |https://jakarta.ee/xml/ns/jaxb |The namespace of the Jakarta
 XML Binding<<bib9>> specification
-|jaxws |http://java.sun.com/xml/ns/jaxws |The namespace of the Jakarta
+|jaxws |https://jakarta.ee/xml/ns/jaxws |The namespace of the Jakarta
 XML Web Services specification
 |wsa |http://www.w3.org/2005/08/addressing |The namespace of the
 WS-Addressing 1.0<<bib26>> schema

--- a/spec/src/main/asciidoc/ch06-core_apis.adoc
+++ b/spec/src/main/asciidoc/ch06-core_apis.adoc
@@ -464,12 +464,7 @@ not meant for end developers but for container or its extension
 developers.
 
 The HTTP SPI allows a deployment to use any available web services
-runtime for HTTP transport. Java EE 6 web profile vendors can support
-JSR-109<<bib17>> deployments using the JAX-WS 2.2
-runtime in Java SE platform. For example, a Servlet 3.0 extension can be
-used to do the JSR-109 deployment by reading deployment descriptors and
-hand-off the request processing to the web services runtime that is in
-Java SE platform.
+runtime for HTTP transport.
 
 The HTTP SPI consists of the following classes:
 
@@ -545,10 +540,3 @@ Typical portable undeployment is done as below:
   3. EndpointN.stop()
 ....
 
-Having a support for this SPI in a Jakarta XML Web Services implementation in Java SE
-platform would enable deployments to use the Java SE platform’s web
-services runtime portably.
-
-&#9674; _Conformance (HTTP SPI in SE platform):_ A JAX-WS 2.2 implementation in Java SE
-platform MUST support
-`Endpoint.publish(jakarta.xml.ws.spi.http.HttpContext)`.

--- a/spec/src/main/asciidoc/ch08-customizations.adoc
+++ b/spec/src/main/asciidoc/ch08-customizations.adoc
@@ -19,27 +19,27 @@ customizations will hereafter be referred to as __binding
 declarations__.
 
 All XML elements defined in this section belong to the
-`http://java.sun.com/xml/ns/jaxws` namespace. For clarity, the rest of
+`https://jakarta.ee/xml/ns/jaxws` namespace. For clarity, the rest of
 this section uses qualified element names exclusively. Wherever it
 appears, the `jaxws` prefix is assumed to be bound to the
-`http://java.sun.com/xml/ns/jaxws` namespace name.
+`https://jakarta.ee/xml/ns/jaxws` namespace name.
 
 The binding language is extensible. Extensions are expressed using
 elements and/or attributes whose namespace name is different from the
 one used by this specification.
 
 &#9674; _Conformance (Standard binding declarations):_
-The `http://java.sun.com/xml/ns/jaxws`
+The `https://jakarta.ee/xml/ns/jaxws`
 namespace is reserved for standard Jakarta XML Web Services binding declarations.
 Implementations MUST support all standard Jakarta XML Web Services binding declarations.
 Implementation-specific binding declaration extensions MUST NOT use the
-`http://java.sun.com/xml/ns/jaxws` namespace.
+`https://jakarta.ee/xml/ns/jaxws` namespace.
 
 &#9674; _Conformance (Binding language extensibility):_
 Implementations MUST ignore unknown
 elements and attributes appearing inside a binding declaration whose
 namespace name is not the one specified in the standard, i.e.
-`http://java.sun.com/xml/ns/jaxws`.
+`https://jakarta.ee/xml/ns/jaxws`.
 
 [[bindingdeclarationcontainer]]
 === Binding Declaration Container
@@ -84,8 +84,8 @@ which have any `jaxws:bindings` ancestors (i.e. on non top-level
 binding declarations).
 
 For the Jakarta XML Web Services specification, the version identifier, if present,
-MUST be `2.0`. If the `@version` attribute is absent, it will implicitly
-be assumed to be `2.0`.
+MUST be `3.0`. If the `@version` attribute is absent, it will implicitly
+be assumed to be `3.0`.
 
 [[embeddedbindingdeclarations]]
 === Embedded Binding Declarations
@@ -334,7 +334,7 @@ the name of a Java field, method, type or package.
 
 The following sections detail the predefined binding declarations,
 classified according to the WSDL element they’re allowed on. All these
-declarations reside in the `http://java.sun.com/xml/ns/jaxws` namespace.
+declarations reside in the `https://jakarta.ee/xml/ns/jaxws` namespace.
 
 [[bindingdecldefinitions]]
 ==== Definitions


### PR DESCRIPTION
Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>